### PR TITLE
docs: adds jsDocs to getNonce

### DIFF
--- a/sapling/src/getNonce.ts
+++ b/sapling/src/getNonce.ts
@@ -1,4 +1,7 @@
-export function getNonce() {
+/**
+ * Function that creates an unique ID string
+ */
+export function getNonce(): string {
   let text = "";
   const possible =
     "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";


### PR DESCRIPTION
# 📝 Description

While I was reading the code, I didn't realized what `getNonce` was at first time, the jsDocs may provide more context to it, just a minor add but can save some one to google it for something like 2 minutes 😅 