### PR TITLE
Decoupled Tree from parser, refactored parser methods.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+    // Prettier auto-format
+    "editor.formatOnPaste": true,
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "eslint.workingDirectories": [
+        "./sapling"
+    ]
+}

--- a/sapling/.eslintignore
+++ b/sapling/.eslintignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+out/
+src/test/
+**/*.d.ts

--- a/sapling/.eslintrc.json
+++ b/sapling/.eslintrc.json
@@ -1,25 +1,133 @@
 {
-    "root": true,
-    "parser": "@typescript-eslint/parser",
-    "parserOptions": {
-        "ecmaVersion": 6,
-        "sourceType": "module"
-    },
-    "plugins": [
-        "@typescript-eslint"
-    ],
-    "rules": {
-        "@typescript-eslint/naming-convention": "warn",
-        "@typescript-eslint/semi": "warn",
-        "curly": "warn",
-        "eqeqeq": "warn",
-        "no-throw-literal": "warn",
-        "semi": "off"
-    },
-    "ignorePatterns": [
-        "out",
-        "dist",
-        "**/*.d.ts",
-        "src/test/test_apps/*"
+  "root": true,
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaVersion": 6,
+    "sourceType": "module",
+    "project": [
+      "./tsconfig.json",
+      "./src/webviews/tsconfig.views.json"
     ]
+  },
+  "plugins": ["@typescript-eslint", "prettier"],
+  "extends": [
+    "eslint:recommended",
+    "airbnb",
+    "airbnb-typescript",
+    "plugin:@typescript-eslint/recommended-requiring-type-checking",
+    "plugin:import/errors",
+    "plugin:import/warnings",
+    "plugin:import/typescript",
+    "plugin:react/recommended",
+    "plugin:react-hooks/recommended",
+    "plugin:prettier/recommended"
+  ],
+  "rules": {
+    "strict": "error",
+    "prettier/prettier": "warn",
+
+    "curly": "warn",
+    "eqeqeq": "warn",
+    "no-throw-literal": "warn",
+    "no-param-reassign": "warn",
+
+    "@typescript-eslint/ban-types": "error",
+    "@typescript-eslint/explicit-module-boundary-types": "error",
+    "@typescript-eslint/lines-between-class-members": "off",
+    "@typescript-eslint/naming-convention": "warn",
+    "@typescript-eslint/no-explicit-any": "error", // forbids "any" usage entirely.
+    // "@typescript-eslint/no-floating/promises": "warn",
+    // "@typescript-eslint/no-inferrable-types": "warn", // prevents explicit declaration of simple, inferrable types
+    "@typescript-eslint/no-non-null-assertion": "warn",
+    // "@typescript-eslint/no-unnecessary-condition": "warn", // shouldn"t be enabled if "any" is used in codebase
+    // "@typescript-eslint/no-unnecessary-type-assertion": "warn",
+    "@typescript-eslint/no-unused-vars": "warn",
+    "@typescript-eslint/no-use-before-define": "warn",
+    // "@typescript-eslint/promise-function-async": "warn",
+    // "@typescript-eslint/require-await": "warn",
+    "@typescript-eslint/semi": "warn",
+
+    /* Uncomment to globally disable individual linter rules */
+
+    "arrow-body-style": "off", // conflicts with prettier
+    "class-methods-use-this": "warn",
+    "consistent-return": "warn",
+    // "comma-dangle": "off",
+    "default-case": "off",
+    // "dot-notation": "off",
+    // "func-names": "off",
+    // "guard-for-in": "off",
+    // "import/extensions": "off",
+    // "import/no-extraneous-dependencies": "off",
+    // "import/no-unresolved": "off",
+    "import/prefer-default-export": "off",
+    // "max-len": "off",
+    // "no-alert": "off",
+    "no-console": "off",
+    // "no-confusing-arrow": "off",
+    "no-nested-ternary": "off",
+    "no-plusplus": "off",
+    // "no-restricted-globals": "off",
+    // "no-restricted-syntax": "off",
+    // "no-shadow": "off",
+    // "no-unexpected-multiline": "off",
+    // "no-unused-vars": "off",
+    // "no-useless-constructor": "off",
+    "no-underscore-dangle": "off",
+    // "no-unused-expressions": "off",
+    "no-return-assign": "warn",
+    "prefer-arrow-callback": "off", // conflicts with prettier
+    // "prefer-destructuring": "off",
+    "prefer-template": "off",
+    // "spaced-comment": "off"
+
+    // "react/boolean-prop-naming": "off",
+    // "react/button-has-type": "off",
+    // "react/destructuring-assignment": "off",
+    // "react/display-name": ["off"],
+    "react/function-component-definition": "off",
+    // "react/forbid-prop-types": "off",
+    "react/jsx-boolean-value": "off",
+    "react/jsx-filename-extension": "off",
+    // "react/jsx-no-duplicate-props": "off",
+    // "react/no-access-state-in-setstate": "off",
+    // "react/no-array-index-key": "off",
+    // "react/no-did-update-set-state": "off",
+    "react/no-unused-prop-types": "warn",
+    // "react/no-unused-state": "off",
+    // "react/prefer-stateless-function": "off",
+    // "react/prop-types": "off",
+    // "react/react-in-jsx-scope": "off"
+    "react-hooks/rules-of-hooks": "error",
+    "react-hooks/exhaustive-deps": "warn",
+
+    /**
+     * This is a compatibility ruleset that:
+     * - disables rules from eslint:recommended which are already handled by TypeScript.
+     * - enables rules that make sense due to TS"s typechecking / transpilation.
+     * See: https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/configs/eslint-recommended.ts
+     */
+    "constructor-super": "off", // ts(2335) & ts(2377)
+    "getter-return": "off", // ts(2378)
+    "no-const-assign": "off", // ts(2588)
+    "no-dupe-args": "off", // ts(2300)
+    "no-dupe-class-members": "off", // ts(2393) & ts(2300)
+    "no-dupe-keys": "off", // ts(1117)
+    "no-func-assign": "off", // ts(2539)
+    "no-import-assign": "off", // ts(2539) & ts(2540)
+    "no-new-symbol": "off", // ts(2588)
+    "no-obj-calls": "off", // ts(2349)
+    "no-redeclare": "off", // ts(2451)
+    "no-setter-return": "off", // ts(2408)
+    "no-this-before-super": "off", // ts(2376)
+    "no-undef": "off", // ts(2304)
+    "no-unreachable": "off", // ts(7027)
+    "no-unsafe-negation": "off", // ts(2365) & ts(2360) & ts(2358)
+    "no-use-before-define": "off",
+    "no-var": "error", // ts transpiles let/const to var, so no need for vars any more
+    "prefer-const": "error", // ts provides better types with const
+    "prefer-rest-params": "error", // ts provides better types with rest args over arguments
+    "prefer-spread": "error", // ts transpiles spread to apply, so no need for manual apply
+    "valid-typeof": "off" // ts(2367)
+  }
 }

--- a/sapling/.eslintrc.json
+++ b/sapling/.eslintrc.json
@@ -76,7 +76,7 @@
     // "no-useless-constructor": "off",
     "no-underscore-dangle": "off",
     // "no-unused-expressions": "off",
-    "no-return-assign": "warn",
+    "no-return-assign": "off",
     "prefer-arrow-callback": "off", // conflicts with prettier
     // "prefer-destructuring": "off",
     "prefer-template": "off",

--- a/sapling/.eslintrc.json
+++ b/sapling/.eslintrc.json
@@ -42,7 +42,7 @@
     // "@typescript-eslint/no-unnecessary-condition": "warn", // shouldn"t be enabled if "any" is used in codebase
     // "@typescript-eslint/no-unnecessary-type-assertion": "warn",
     "@typescript-eslint/no-unused-vars": "warn",
-    "@typescript-eslint/no-use-before-define": "warn",
+    "@typescript-eslint/no-use-before-define": "off",
     // "@typescript-eslint/promise-function-async": "warn",
     // "@typescript-eslint/require-await": "warn",
     "@typescript-eslint/semi": "warn",
@@ -58,6 +58,7 @@
     // "func-names": "off",
     // "guard-for-in": "off",
     // "import/extensions": "off",
+    "import/no-cycle": "warn",
     // "import/no-extraneous-dependencies": "off",
     // "import/no-unresolved": "off",
     "import/prefer-default-export": "off",

--- a/sapling/.prettierrc
+++ b/sapling/.prettierrc
@@ -1,0 +1,16 @@
+{
+  "arrowParens": "always",
+  "bracketSpacing": true,
+  "htmlWhitespaceSensitivity": "css",
+  "jsxBracketSameLine": false,
+  "jsxSingleQuote": false,
+  "printWidth": 100,
+  "proseWrap": "preserve",
+  "quoteProps": "as-needed",
+  "semi": true,
+  "singleQuote": true,
+  "tabWidth": 2,
+  "trailingComma": "es5",
+  "useTabs": false,
+  "parser": "typescript"
+}

--- a/sapling/package.json
+++ b/sapling/package.json
@@ -117,6 +117,7 @@
 		"css-loader": "^6.2.0",
 		"eslint": "^8.3.0",
 		"eslint-config-airbnb": "^19.0.0",
+		"eslint-config-airbnb-base": "^15.0.0",
 		"eslint-config-airbnb-typescript": "^16.0.0",
 		"eslint-config-prettier": "^8.3.0",
 		"eslint-plugin-import": "^2.25.3",

--- a/sapling/package.json
+++ b/sapling/package.json
@@ -1,141 +1,151 @@
 {
-  "name": "sapling",
-  "displayName": "Sapling",
-  "description": "React Component Hierarchy Visualizer",
-  "repository": "https://github.com/oslabs-beta/sapling",
-  "icon": "media/sapling-logo-128px.png",
-  "publisher": "team-sapling",
-  "version": "1.2.0",
-  "engines": {
-    "vscode": "^1.60.0"
-  },
-  "categories": [
-    "Visualization"
-  ],
-  "keywords": [
-    "react",
-    "component hierarchy",
-    "devtools"
-  ],
-  "activationEvents": [
-    "onStartupFinished"
-  ],
-  "main": "./dist/extension.js",
-  "contributes": {
-    "viewsContainers": {
-      "activitybar": [
-        {
-          "id": "sapling-sidebar-view",
-          "title": "sapling",
-          "icon": "media/list-tree.svg"
-        }
-      ]
-    },
-    "views": {
-      "sapling-sidebar-view": [
-        {
-          "type": "webview",
-          "id": "sapling-sidebar",
-          "name": "sapling",
-          "icon": "media/list-tree.svg",
-          "contextualTitle": "sapling"
-        }
-      ]
-    },
-    "commands": [
-      {
-        "command": "sapling.refresh",
-        "category": "Sapling",
-        "title": "Refresh"
-      },
-      {
-        "command": "sapling.generateTree",
-        "category": "Sapling",
-        "title": "Generate Tree"
-      }
-    ],
-    "menus" : {
-      "commandPalette": [
-        {
-          "command": "sapling.generateTree",
-          "when": "resourceLangId == javascript || resourceLangId == javascriptreact || resourceLangId == typescript || resourceLangId == typescriptreact"
-        }
-      ],
-      "explorer/context": [
-        {
-          "when": "resourceLangId == javascript || resourceLangId == javascriptreact || resourceLangId == typescript || resourceLangId == typescriptreact",
-          "command": "sapling.generateTree",
-          "group": "sapling"
-        }
-      ]
-    },
-    "configuration": {
-      "title": "Sapling",
-      "properties": {
-        "sapling.view.thirdParty": {
-          "type": "boolean",
-          "default": true,
-          "description": "Show Third Party components in the tree view."
-        },
-        "sapling.view.reactRouter": {
-          "type": "boolean",
-          "default": true,
-          "description": "Show React Router components in the tree view."
-        }
-      }
-    }
-  },
-  "scripts": {
-    "vscode:prepublish": "npm run package",
-    "build": "npm-run-all -p build:*",
-    "build:extension": "webpack --mode production",
-    "build:sidebar": "webpack --config ./src/webviews/webpack.views.config.js",
-    "watch": "npm-run-all -p watch:*",
-    "watch:extension": "webpack --watch",
-    "watch:sidebar": "webpack --watch --config ./src/webviews/webpack.views.config.js",
-    "package": "webpack --mode production --devtool hidden-source-map && webpack --config ./src/webviews/webpack.views.config.js --devtool hidden-source-map",
-    "test-compile": "tsc -p ./",
-    "test-watch": "tsc -watch -p ./",
-    "pretest": "npm run test-compile && npm run lint",
-    "lint": "eslint src --ext ts",
-    "test": "node ./out/test/runTest.js",
-    "test-mocha": "npm run pretest && npx mocha out/test/suite/parser.test.js"
-  },
-  "devDependencies": {
-    "@babel/parser": "^7.15.7",
-    "@babel/types": "^7.15.6",
-    "@testing-library/react": "^12.1.0",
-    "@types/chai": "^4.2.22",
-    "@types/glob": "^7.1.3",
-    "@types/jsdom": "^16.2.13",
-    "@types/mocha": "^8.2.2",
-    "@types/node": "14.x",
-    "@types/react": "^17.0.21",
-    "@types/react-dom": "^17.0.9",
-    "@types/vscode": "^1.60.0",
-    "@typescript-eslint/eslint-plugin": "^4.26.0",
-    "@typescript-eslint/parser": "^4.26.0",
-    "chai": "^4.3.4",
-    "css-loader": "^6.2.0",
-    "eslint": "^7.27.0",
-    "glob": "^7.1.7",
-    "global-jsdom": "^8.2.0",
-    "jsdom": "^17.0.0",
-    "mocha": "^8.4.0",
-    "npm-run-all": "^4.1.5",
-    "style-loader": "^3.2.1",
-    "ts-loader": "^9.2.2",
-    "typescript": "^4.3.2",
-    "vscode-test": "^1.5.2",
-    "webpack": "^5.38.1",
-    "webpack-cli": "^4.7.0"
-  },
-  "dependencies": {
-    "@fortawesome/fontawesome-svg-core": "^1.2.36",
-    "@fortawesome/free-solid-svg-icons": "^5.15.4",
-    "@fortawesome/react-fontawesome": "^0.1.15",
-    "@tippy.js/react": "^3.1.1",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2"
-  }
+	"name": "sapling",
+	"displayName": "Sapling",
+	"description": "React Component Hierarchy Visualizer",
+	"repository": "https://github.com/oslabs-beta/sapling",
+	"icon": "media/sapling-logo-128px.png",
+	"publisher": "team-sapling",
+	"version": "1.2.0",
+	"engines": {
+		"vscode": "^1.60.0"
+	},
+	"categories": [
+		"Visualization"
+	],
+	"keywords": [
+		"react",
+		"component hierarchy",
+		"devtools"
+	],
+	"activationEvents": [
+		"onStartupFinished"
+	],
+	"main": "./dist/extension.js",
+	"contributes": {
+		"viewsContainers": {
+			"activitybar": [
+				{
+					"id": "sapling-sidebar-view",
+					"title": "sapling",
+					"icon": "media/list-tree.svg"
+				}
+			]
+		},
+		"views": {
+			"sapling-sidebar-view": [
+				{
+					"type": "webview",
+					"id": "sapling-sidebar",
+					"name": "sapling",
+					"icon": "media/list-tree.svg",
+					"contextualTitle": "sapling"
+				}
+			]
+		},
+		"commands": [
+			{
+				"command": "sapling.refresh",
+				"category": "Sapling",
+				"title": "Refresh"
+			},
+			{
+				"command": "sapling.generateTree",
+				"category": "Sapling",
+				"title": "Generate Tree"
+			}
+		],
+		"menus": {
+			"commandPalette": [
+				{
+					"command": "sapling.generateTree",
+					"when": "resourceLangId == javascript || resourceLangId == javascriptreact || resourceLangId == typescript || resourceLangId == typescriptreact"
+				}
+			],
+			"explorer/context": [
+				{
+					"when": "resourceLangId == javascript || resourceLangId == javascriptreact || resourceLangId == typescript || resourceLangId == typescriptreact",
+					"command": "sapling.generateTree",
+					"group": "sapling"
+				}
+			]
+		},
+		"configuration": {
+			"title": "Sapling",
+			"properties": {
+				"sapling.view.thirdParty": {
+					"type": "boolean",
+					"default": true,
+					"description": "Show Third Party components in the tree view."
+				},
+				"sapling.view.reactRouter": {
+					"type": "boolean",
+					"default": true,
+					"description": "Show React Router components in the tree view."
+				}
+			}
+		}
+	},
+	"scripts": {
+		"vscode:prepublish": "npm run package",
+		"build": "npm-run-all -p build:*",
+		"build:extension": "webpack --mode production",
+		"build:sidebar": "webpack --config ./src/webviews/webpack.views.config.js",
+		"watch": "npm-run-all -p watch:*",
+		"watch:extension": "webpack --watch",
+		"watch:sidebar": "webpack --watch --config ./src/webviews/webpack.views.config.js",
+		"package": "webpack --mode production --devtool hidden-source-map && webpack --config ./src/webviews/webpack.views.config.js --devtool hidden-source-map",
+		"test-compile": "tsc -p ./",
+		"test-watch": "tsc -watch -p ./",
+		"pretest": "npm run test-compile && npm run lint",
+		"lint": "eslint src --ext ts",
+		"test": "node ./out/test/runTest.js",
+		"test-mocha": "npm run pretest && npx mocha out/test/suite/parser.test.js"
+	},
+	"devDependencies": {
+		"@testing-library/react": "^12.1.0",
+		"@types/chai": "^4.2.22",
+		"@types/glob": "^7.1.3",
+		"@types/jsdom": "^16.2.13",
+		"@types/mocha": "^8.2.2",
+		"@types/node": "14.x",
+		"@types/react": "^17.0.21",
+		"@types/react-dom": "^17.0.9",
+		"@types/vscode": "^1.60.0",
+		"@typescript-eslint/eslint-plugin": "^5.4.0",
+		"@typescript-eslint/parser": "^5.4.0",
+		"chai": "^4.3.4",
+		"css-loader": "^6.2.0",
+		"eslint": "^8.3.0",
+		"eslint-config-airbnb": "^19.0.0",
+		"eslint-config-airbnb-typescript": "^16.0.0",
+		"eslint-config-prettier": "^8.3.0",
+		"eslint-plugin-import": "^2.25.3",
+		"eslint-plugin-jsx-a11y": "^6.5.1",
+		"eslint-plugin-prettier": "^4.0.0",
+		"eslint-plugin-react": "^7.27.1",
+		"eslint-plugin-react-hooks": "^4.3.0",
+		"glob": "^7.1.7",
+		"global-jsdom": "^8.2.0",
+		"jsdom": "^17.0.0",
+		"mocha": "^8.4.0",
+		"npm-run-all": "^4.1.5",
+		"prettier": "^2.5.0",
+		"style-loader": "^3.2.1",
+		"ts-loader": "^9.2.2",
+		"typescript": "^4.3.2",
+		"vscode-test": "^1.5.2",
+		"webpack": "^5.38.1",
+		"webpack-cli": "^4.7.0"
+	},
+	"dependencies": {
+		"@babel/parser": "^7.15.7",
+		"@babel/types": "^7.15.6",
+		"@fortawesome/fontawesome-svg-core": "^1.2.36",
+		"@fortawesome/free-solid-svg-icons": "^5.15.4",
+		"@fortawesome/react-fontawesome": "^0.1.15",
+		"@tippy.js/react": "^3.1.1",
+		"react": "^17.0.2",
+		"react-dom": "^17.0.2",
+		"vscode-test": "^1.6.1"
+	}
 }

--- a/sapling/package.json
+++ b/sapling/package.json
@@ -146,6 +146,7 @@
 		"@tippy.js/react": "^3.1.1",
 		"react": "^17.0.2",
 		"react-dom": "^17.0.2",
+		"tippy.js": "^6.3.7",
 		"vscode-test": "^1.6.1"
 	}
 }

--- a/sapling/src/SaplingParser.ts
+++ b/sapling/src/SaplingParser.ts
@@ -380,7 +380,7 @@ export class SaplingParser {
       /* React lazy loading import
        * e.g. const foo = React.lazy(() => import('./module'));
        */
-      importPath = this.parseLazyLoading(declarator);
+      importPath = this.parseNestedDynamicImports(declarator);
       if (importPath.length && isIdentifier(declarator.id)) {
         importName = declarator.id.name;
         output[importAlias || importName] = {
@@ -394,7 +394,7 @@ export class SaplingParser {
   }
 
   // TODO: Explicit parsing of nested Import CallExpression in ArrowFunctionExpression body
-  private parseLazyLoading(ast: ASTNode): string {
+  private parseNestedDynamicImports(ast: ASTNode): string {
     const recurse = (node: ASTNode): string | void => {
       if (isCallExpression(node) && isImport(node.callee) && isStringLiteral(node.arguments[0])) {
         return node.arguments[0].value;

--- a/sapling/src/SaplingParser.ts
+++ b/sapling/src/SaplingParser.ts
@@ -56,12 +56,12 @@ export class SaplingParser {
       fileName: path.basename(this.entryFile),
       filePath: this.entryFile,
       importPath: '/', // this.entryFile here breaks windows file path on root e.g. C:\\ is detected as third party
-      expanded: false,
+      isExpanded: false,
       depth: 0,
       count: 1,
-      thirdParty: false,
-      reactRouter: false,
-      reduxConnect: false,
+      isThirdParty: false,
+      isReactRouter: false,
+      hasReduxConnect: false,
       children: [],
       parentList: [],
       props: {},
@@ -92,15 +92,15 @@ export class SaplingParser {
     type ChildInfo = {
       depth: number;
       filePath: string;
-      expanded: boolean;
+      isExpanded: boolean;
     };
 
     let children: Array<ChildInfo> = [];
 
     const getChildNodes = (node: Tree): void => {
       // eslint-disable-next-line @typescript-eslint/no-shadow
-      const { depth, filePath, expanded } = node;
-      children.push({ depth, filePath, expanded });
+      const { depth, filePath, isExpanded } = node;
+      children.push({ depth, filePath, isExpanded });
     };
 
     const matchExpand = (node: Tree): void => {
@@ -109,9 +109,9 @@ export class SaplingParser {
         if (
           oldNode.depth === node.depth &&
           oldNode.filePath === node.filePath &&
-          oldNode.expanded
+          oldNode.isExpanded
         ) {
-          node.expanded = true;
+          node.isExpanded = true;
         }
       }
     };
@@ -136,10 +136,10 @@ export class SaplingParser {
   }
 
   // Traverses the tree and changes expanded property of node whose id matches provided id
-  public toggleNode(id: string, expanded: boolean): Tree | undefined {
+  public toggleNode(id: string, expandedState: boolean): Tree | undefined {
     const callback = (node: Tree) => {
       if (node.id === id) {
-        node.expanded = expanded;
+        node.isExpanded = expandedState;
       }
     };
 
@@ -165,12 +165,12 @@ export class SaplingParser {
   private parser(componentTree: Tree): Tree {
     // If import is a node module, do not parse any deeper
     if (!['\\', '/', '.'].includes(componentTree.importPath[0])) {
-      componentTree.thirdParty = true;
+      componentTree.isThirdParty = true;
       if (
         componentTree.fileName === 'react-router-dom' ||
         componentTree.fileName === 'react-router'
       ) {
-        componentTree.reactRouter = true;
+        componentTree.isReactRouter = true;
       }
       return componentTree;
     }
@@ -217,7 +217,7 @@ export class SaplingParser {
     componentTree.children = this.getJSXChildren(ast.tokens, imports, componentTree);
 
     // Check if current node is connected to the Redux store
-    componentTree.reduxConnect = this.checkForRedux(ast.tokens, imports);
+    componentTree.hasReduxConnect = this.checkForRedux(ast.tokens, imports);
 
     // Recursively parse all child components
     componentTree.children.forEach((child) => this.parser(child));
@@ -449,11 +449,11 @@ export class SaplingParser {
         fileName: path.basename(filePath),
         filePath,
         importPath: moduleIdentifier,
-        expanded: false,
+        isExpanded: false,
         depth: parent.depth + 1,
-        thirdParty: false,
-        reactRouter: false,
-        reduxConnect: false,
+        isThirdParty: false,
+        isReactRouter: false,
+        hasReduxConnect: false,
         count: 1,
         props,
         children: [],

--- a/sapling/src/SaplingParser.ts
+++ b/sapling/src/SaplingParser.ts
@@ -52,7 +52,7 @@ export class SaplingParser {
     // Create root Tree node
     const root = {
       id: getNonce(),
-      name: path.basename(this.entryFile).replace(/\.(t|j)sx?$/, ''),
+      name: path.basename(this.entryFile).replace(/\.[jt]sx?$/, ''),
       fileName: path.basename(this.entryFile),
       filePath: this.entryFile,
       importPath: '/', // this.entryFile here breaks windows file path on root e.g. C:\\ is detected as third party
@@ -421,7 +421,7 @@ export class SaplingParser {
     }
     // Checks that file exists and appends file extension to path if not given in import declaration
     parsedFileName =
-      fileArray.find((str) => new RegExp(`${path.basename(filePath)}\\.(j|t)sx?$`).test(str)) || '';
+      fileArray.find((str) => new RegExp(`${path.basename(filePath)}\\.[jt]sx?$`).test(str)) || '';
     if (parsedFileName.length) return filePath + path.extname(parsedFileName);
     return filePath;
   }

--- a/sapling/src/SaplingParser.ts
+++ b/sapling/src/SaplingParser.ts
@@ -124,7 +124,7 @@ const ASTParser = {
           // 'importMeta': https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import.meta
           // 'importAssertions': parses ImportAttributes type
           // https://github.com/babel/babel/blob/main/packages/babel-parser/ast/spec.md#ImportAssertions
-          allowImportExportEverywhere: true, // enables parsing dynamic imports
+          allowImportExportEverywhere: true, // enables parsing dynamic imports and exports in body
           attachComment: false, // performance benefits
         });
         // If no ast or ast tokens, error when parsing file
@@ -159,9 +159,10 @@ const ASTParser = {
     children: Record<string, Tree>
   ): Record<string, Tree> {
     const childNodes = { ...children };
-    if (children[astToken.value]) {
-      childNodes[astToken.value].count += 1;
-      Object.assign(childNodes[astToken.value].props, props);
+    const currentNode = children[astToken.value];
+    if (currentNode) {
+      currentNode.set('count', currentNode.count + 1);
+      Object.assign(currentNode.props, props);
     } else {
       const moduleIdentifier = imports[astToken.value].importPath;
       const name = imports[astToken.value].importName;

--- a/sapling/src/SaplingParser.ts
+++ b/sapling/src/SaplingParser.ts
@@ -1,6 +1,15 @@
-import * as babelParser from '@babel/parser';
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable no-prototype-builtins */
+/* eslint-disable @typescript-eslint/no-unsafe-return */
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
+/* eslint-disable no-restricted-syntax */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+
 import * as path from 'path';
 import * as fs from 'fs';
+
+import { parse as babelParse } from '@babel/parser';
 import { getNonce } from "./getNonce";
 import { Tree } from './types/Tree';
 import { ImportObj } from './types/ImportObj';
@@ -17,10 +26,13 @@ export class SaplingParser {
     if (process.platform === 'linux' && this.entryFile.includes('wsl$')) {
       this.entryFile = path.resolve(filePath.split(path.win32.sep).join(path.posix.sep));
       this.entryFile = '/' + this.entryFile.split('/').slice(3).join('/');
-    // Fix for when running wsl but selecting files held on windows file system
-    } else if (process.platform === 'linux' && (/[a-zA-Z]/).test(this.entryFile[0])) {
+      // Fix for when running wsl but selecting files held on windows file system
+    } else if (process.platform === 'linux' && /[a-zA-Z]/.test(this.entryFile[0])) {
       const root = `/mnt/${this.entryFile[0].toLowerCase()}`;
-      this.entryFile = path.join(root, filePath.split(path.win32.sep).slice(1).join(path.posix.sep));
+      this.entryFile = path.join(
+        root,
+        filePath.split(path.win32.sep).slice(1).join(path.posix.sep)
+      );
     }
 
     this.tree = undefined;
@@ -28,13 +40,13 @@ export class SaplingParser {
   }
 
   // Public method to generate component tree based on current entryFile
-  public parse() : Tree {
+  public parse(): Tree {
     // Create root Tree node
     const root = {
       id: getNonce(),
       name: path.basename(this.entryFile).replace(/\.(t|j)sx?$/, ''),
       fileName: path.basename(this.entryFile),
-      filePath : this.entryFile,
+      filePath: this.entryFile,
       importPath: '/', // this.entryFile here breaks windows file path on root e.g. C:\\ is detected as third party
       expanded: false,
       depth: 0,
@@ -45,7 +57,7 @@ export class SaplingParser {
       children: [],
       parentList: [],
       props: {},
-      error: ''
+      error: '',
     };
 
     this.tree = root;
@@ -53,66 +65,71 @@ export class SaplingParser {
     return this.tree;
   }
 
-  public getTree() : Tree | undefined {
+  public getTree(): Tree | undefined {
     return this.tree;
   }
 
   // Set Sapling Parser with a specific Data Tree (from workspace state)
-  public setTree(tree : Tree) : void {
+  public setTree(tree: Tree): void {
     this.entryFile = tree.filePath;
     this.tree = tree;
   }
 
   // Updates the tree when a file is saved in VS Code
-  public updateTree(filePath : string) : Tree | undefined {
-      if (this.tree === undefined) {
-        return this.tree;
-      }
-
-      type ChildInfo = {
-        depth: number,
-        filePath: string,
-        expanded: boolean
-      };
-
-      let children : Array<ChildInfo> = [];
-
-      const getChildNodes = (node: Tree) : void => {
-        const { depth, filePath, expanded } = node;
-        children.push({ depth, filePath, expanded });
-      };
-
-      const matchExpand = (node: Tree) : void => {
-        for (let i = 0 ; i < children.length ; i += 1) {
-          const oldNode = children[i];
-            if (oldNode.depth === node.depth && oldNode.filePath === node.filePath && oldNode.expanded) {
-              node.expanded = true;
-            }
-        }
-      };
-
-      const callback = (node: Tree) : void => {
-        if (node.filePath === filePath) {
-          node.children.forEach(child => {
-            this.#traverseTree(getChildNodes, child);
-          });
-
-          const newNode = this.parser(node);
-
-          this.#traverseTree(matchExpand, newNode);
-
-          children = [];
-        }
-      };
-
-      this.#traverseTree(callback, this.tree);
-
+  public updateTree(filePath: string): Tree | undefined {
+    if (this.tree === undefined) {
       return this.tree;
     }
 
+    type ChildInfo = {
+      depth: number;
+      filePath: string;
+      expanded: boolean;
+    };
+
+    let children: Array<ChildInfo> = [];
+
+    const getChildNodes = (node: Tree): void => {
+      // eslint-disable-next-line @typescript-eslint/no-shadow
+      const { depth, filePath, expanded } = node;
+      children.push({ depth, filePath, expanded });
+    };
+
+    const matchExpand = (node: Tree): void => {
+      for (let i = 0; i < children.length; i += 1) {
+        const oldNode = children[i];
+        if (
+          oldNode.depth === node.depth &&
+          oldNode.filePath === node.filePath &&
+          oldNode.expanded
+        ) {
+          node.expanded = true;
+        }
+      }
+    };
+
+    const callback = (node: Tree): void => {
+      if (node.filePath === filePath) {
+        node.children.forEach((child) => {
+          this.#traverseTree(getChildNodes, child);
+        });
+
+        const newNode = this.parser(node);
+
+        this.#traverseTree(matchExpand, newNode);
+
+        children = [];
+      }
+    };
+
+    this.#traverseTree(callback, this.tree);
+
+    return this.tree;
+  }
+
   // Traverses the tree and changes expanded property of node whose id matches provided id
-  public toggleNode(id : string, expanded : boolean) : Tree | undefined {
-    const callback = (node : Tree) => {
+  public toggleNode(id: string, expanded: boolean): Tree | undefined {
+    const callback = (node: Tree) => {
       if (node.id === id) {
         node.expanded = expanded;
       }
@@ -131,18 +148,20 @@ export class SaplingParser {
 
     callback(node);
 
-    node.children.forEach( (childNode) => {
+    node.children.forEach((childNode) => {
       this.#traverseTree(callback, childNode);
     });
   }
 
   // Recursively builds the React component tree structure starting from root node
-  private parser(componentTree: Tree) : Tree {
-
+  private parser(componentTree: Tree): Tree {
     // If import is a node module, do not parse any deeper
     if (!['\\', '/', '.'].includes(componentTree.importPath[0])) {
       componentTree.thirdParty = true;
-      if (componentTree.fileName === 'react-router-dom' || componentTree.fileName === 'react-router') {
+      if (
+        componentTree.fileName === 'react-router-dom' ||
+        componentTree.fileName === 'react-router'
+      ) {
         componentTree.reactRouter = true;
       }
       return componentTree;
@@ -190,24 +209,23 @@ export class SaplingParser {
     componentTree.reduxConnect = this.checkForRedux(ast.tokens, imports);
 
     // Recursively parse all child components
-    componentTree.children.forEach(child => this.parser(child));
+    componentTree.children.forEach((child) => this.parser(child));
 
     return componentTree;
   }
 
   // Finds files where import string does not include a file extension
-  private getFileName(componentTree: Tree) : string | null {
+  private getFileName(componentTree: Tree): string | null {
     const ext = path.extname(componentTree.filePath);
 
     if (!ext) {
       // Try and find file extension that exists in directory:
       const fileArray = fs.readdirSync(path.dirname(componentTree.filePath));
       const regEx = new RegExp(`${componentTree.fileName}.(j|t)sx?$`);
-      let fileName = fileArray.find(fileStr => fileStr.match(regEx));
-      return fileName ? componentTree.filePath += path.extname(fileName) : null;
-    } else {
-      return componentTree.fileName;
+      const fileName = fileArray.find((fileStr) => fileStr.match(regEx));
+      return fileName ? (componentTree.filePath += path.extname(fileName)) : null;
     }
+    return componentTree.fileName;
   }
 
   // Extracts Imports from current file
@@ -215,14 +233,18 @@ export class SaplingParser {
   // import Page2 from './page2'; -> is parsed as 'VariableDeclaration'
   private getImports(body : {[key : string]: any}[]) : ImportObj {
     const bodyImports = body.filter(item => item.type === 'ImportDeclaration' || 'VariableDeclaration');
+    const bodyImports = body.filter(
+      (item) => item.type === 'ImportDeclaration' || 'VariableDeclaration'
+    );
     // console.log('bodyImports are: ', bodyImports);
     return bodyImports.reduce((accum, curr) => {
       // Import Declarations:
       if (curr.type === 'ImportDeclaration') {
         curr.specifiers.forEach((i : {[key : string]: any}) => {
+          // @ts-ignore
           accum[i.local.name] = {
             importPath: curr.source.value,
-            importName: (i.imported)? i.imported.name : i.local.name
+            importName: i.imported ? i.imported.name : i.local.name,
           };
         });
       }
@@ -230,10 +252,12 @@ export class SaplingParser {
       if (curr.type === 'VariableDeclaration') {
         const importPath = this.findVarDecImports(curr.declarations[0]);
         if (importPath) {
+          // @ts-ignore
           const importName = curr.declarations[0].id.name;
+          // @ts-ignore
           accum[curr.declarations[0].id.name] = {
             importPath,
-            importName
+            importName,
           };
         }
       }
@@ -244,17 +268,19 @@ export class SaplingParser {
   // Recursive helper method to find import path in Variable Declaration
   private findVarDecImports(ast: {[key: string]: any}) : string | boolean {
     // Base Case, find import path in variable declaration and return it,
+    // @ts-ignore
     if (ast.hasOwnProperty('callee') && ast.callee.type === 'Import') {
+      // @ts-ignore
       return ast.arguments[0].value;
     }
 
     // Otherwise look for imports in any other non null/undefined objects in the tree:
-    for (let key in ast) {
-      if (ast.hasOwnProperty(key) && typeof ast[key] === 'object' && ast[key]) {
+    for (const key in ast) {
+      // @ts-ignore
+      if (ast[key] && typeof ast[key] === 'object') {
+        // @ts-ignore
         const importPath = this.findVarDecImports(ast[key]);
-        if (importPath) {
-          return importPath;
-        }
+        if (importPath) return importPath;
       }
     }
 
@@ -269,19 +295,23 @@ export class SaplingParser {
 
     for (let i = 0; i < astTokens.length; i++) {
       // Case for finding JSX tags eg <App .../>
-      if (astTokens[i].type.label === 'jsxTagStart'
-      && astTokens[i + 1].type.label === 'jsxName'
-      && importsObj[astTokens[i + 1].value]) {
+      if (
+        astTokens[i].type.label === 'jsxTagStart' &&
+        astTokens[i + 1].type.label === 'jsxName' &&
+        imports[astTokens[i + 1].value]
+      ) {
         token = astTokens[i + 1];
         props = this.getJSXProps(astTokens, i + 2);
-        childNodes = this.getChildNodes(importsObj, token, props, parentNode, childNodes);
+        childNodes = this.getChildNodes(imports, token, props, parentNode, childNodes);
 
         // Case for finding components passed in as props e.g. <Route component={App} />
-      } else if (astTokens[i].type.label === 'jsxName'
-      && (astTokens[i].value === 'component' || astTokens[i].value === 'children')
-      && importsObj[astTokens[i + 3].value]) {
+      } else if (
+        astTokens[i].type.label === 'jsxName' &&
+        (astTokens[i].value === 'component' || astTokens[i].value === 'children') &&
+        imports[astTokens[i + 3].value]
+      ) {
         token = astTokens[i + 3];
-        childNodes = this.getChildNodes(importsObj, token, props, parentNode, childNodes);
+        childNodes = this.getChildNodes(imports, token, props, parentNode, childNodes);
       }
     }
 
@@ -294,22 +324,22 @@ export class SaplingParser {
 
     if (children[astToken.value]) {
       children[astToken.value].count += 1;
-      children[astToken.value].props = {...children[astToken.value].props, ...props};
+      children[astToken.value].props = { ...children[astToken.value].props, ...props };
     } else {
       // Add tree node to childNodes if one does not exist
       children[astToken.value] = {
         id: getNonce(),
-        name: imports[astToken.value]['importName'],
-        fileName: path.basename(imports[astToken.value]['importPath']),
-        filePath: path.resolve(path.dirname(parent.filePath), imports[astToken.value]['importPath']),
-        importPath: imports[astToken.value]['importPath'],
+        name: imports[astToken.value].importName,
+        fileName: path.basename(imports[astToken.value].importPath),
+        filePath: path.resolve(path.dirname(parent.filePath), imports[astToken.value].importPath),
+        importPath: imports[astToken.value].importPath,
         expanded: false,
         depth: parent.depth + 1,
         thirdParty: false,
         reactRouter: false,
         reduxConnect: false,
         count: 1,
-        props: props,
+        props,
         children: [],
         parentList: [parent.filePath].concat(parent.parentList),
         error: '',
@@ -324,6 +354,8 @@ export class SaplingParser {
     const props : {[key : string]: boolean} = {};
     while (astTokens[j].type.label !== "jsxTagEnd") {
       if (astTokens[j].type.label === "jsxName" && astTokens[j + 1].value === "=") {
+    while (astTokens[j].type.label !== 'jsxTagEnd') {
+      if (astTokens[j].type.label === 'jsxName' && astTokens[j + 1].value === '=') {
         props[astTokens[j].value] = true;
       }
       j += 1;
@@ -336,8 +368,8 @@ export class SaplingParser {
     // Check that react-redux is imported in this file (and we have a connect method or otherwise)
     let reduxImported = false;
     let connectAlias;
-    Object.keys(importsObj).forEach( key => {
-      if (importsObj[key].importPath === 'react-redux' && importsObj[key].importName === 'connect') {
+    Object.keys(imports).forEach((key) => {
+      if (imports[key].importPath === 'react-redux' && imports[key].importName === 'connect') {
         reduxImported = true;
         connectAlias = key;
       }
@@ -349,7 +381,11 @@ export class SaplingParser {
 
     // Check that connect method is invoked and exported in the file
     for (let i = 0; i < astTokens.length; i += 1) {
-      if (astTokens[i].type.label === 'export' && astTokens[i + 1].type.label === 'default' && astTokens[i + 2].value === connectAlias) {
+      if (
+        astTokens[i].type.label === 'export' &&
+        astTokens[i + 1].type.label === 'default' &&
+        astTokens[i + 2].value === connectAlias
+      ) {
         return true;
       }
     }

--- a/sapling/src/SaplingParser.ts
+++ b/sapling/src/SaplingParser.ts
@@ -144,6 +144,9 @@ const ASTParser = {
 
       // Check if current node is connected to the Redux store
       componentTree.set('hasReduxConnect', ASTParser.checkForRedux(ast.tokens, imports));
+
+      // Remove any existing error messages if no errors have been found during current pass.
+      componentTree.set('error', '');
     };
     root.traverse(recurse);
   },

--- a/sapling/src/SaplingParser.ts
+++ b/sapling/src/SaplingParser.ts
@@ -15,6 +15,8 @@ import { Tree } from './types/Tree';
 import { ImportObj } from './types/ImportObj';
 import { File } from '@babel/types';
 
+import { Tree, Token, ImportData } from './types';
+import { getNonce } from './helpers/getNonce';
 
 export class SaplingParser {
   entryFile: string;

--- a/sapling/src/SaplingParser.ts
+++ b/sapling/src/SaplingParser.ts
@@ -209,18 +209,15 @@ export class SaplingParser {
       componentTree.error = 'Error while processing this file/node';
       return componentTree;
     }
-    const { tokens } = ast;
-    let tokenList: Array<Token> = [];
-    if (tokens) tokenList = tokens as Array<Token>;
 
     // Find imports in the current file, then find child components in the current file
     const imports = this.getImports(ast.program.body);
 
     // Get any JSX Children of current file:
-    componentTree.children = this.getJSXChildren(tokenList, imports, componentTree);
+    componentTree.children = this.getJSXChildren(ast.tokens, imports, componentTree);
 
     // Check if current node is connected to the Redux store
-    componentTree.reduxConnect = this.checkForRedux(tokenList, imports);
+    componentTree.reduxConnect = this.checkForRedux(ast.tokens, imports);
 
     // Recursively parse all child components
     componentTree.children.forEach((child) => this.parser(child));

--- a/sapling/src/SaplingParser.ts
+++ b/sapling/src/SaplingParser.ts
@@ -69,7 +69,7 @@ export class SaplingParser {
     };
 
     this.tree = root;
-    this.parser(root);
+    ASTParser.parser(root);
     return this.tree;
   }
 
@@ -122,7 +122,7 @@ export class SaplingParser {
           this.#traverseTree(getChildNodes, child);
         });
 
-        const newNode = this.parser(node);
+        const newNode = ASTParser.parser(node);
 
         this.#traverseTree(matchExpand, newNode);
 
@@ -160,9 +160,11 @@ export class SaplingParser {
       this.#traverseTree(callback, childNode);
     });
   }
+}
 
+const ASTParser = {
   // Recursively builds the React component tree structure starting from root node
-  private parser(componentTree: Tree): Tree {
+  parser(componentTree: Tree): Tree {
     // If import is a node module, do not parse any deeper
     if (!['\\', '/', '.'].includes(componentTree.importPath[0])) {
       componentTree.thirdParty = true;
@@ -211,42 +213,174 @@ export class SaplingParser {
     }
 
     // Find imports in the current file, then find child components in the current file
-    const imports = this.getImports(ast.program.body);
+    const imports = ImportParser.parse(ast.program.body);
 
     // Get any JSX Children of current file:
-    componentTree.children = this.getJSXChildren(ast.tokens, imports, componentTree);
+    componentTree.children = ASTParser.getJSXChildren(ast.tokens, imports, componentTree);
 
     // Check if current node is connected to the Redux store
-    componentTree.reduxConnect = this.checkForRedux(ast.tokens, imports);
+    componentTree.reduxConnect = ASTParser.checkForRedux(ast.tokens, imports);
 
     // Recursively parse all child components
-    componentTree.children.forEach((child) => this.parser(child));
+    componentTree.children.forEach((child) => ASTParser.parser(child));
 
     return componentTree;
-  }
+  },
 
+  validateFilePath(filePath: string): string {
+    const fileArray: string[] = [];
+    let parsedFileName = '';
+    // Handles Next.js component and other third-party imports
+    try {
+      fileArray.push(...fs.readdirSync(path.dirname(filePath)));
+    } catch {
+      return filePath;
+    }
+    // Checks that file exists and appends file extension to path if not given in import declaration
+    parsedFileName =
+      fileArray.find((str) => new RegExp(`${path.basename(filePath)}\\.[jt]sx?$`).test(str)) || '';
+    if (parsedFileName.length) return filePath + path.extname(parsedFileName);
+    return filePath;
+  },
+
+  getChildNodes(
+    imports: Record<string, ImportData>,
+    astToken: Token,
+    props: Record<string, boolean>,
+    parent: Tree,
+    children: Record<string, Tree>
+  ): Record<string, Tree> {
+    if (children[astToken.value]) {
+      children[astToken.value].count += 1;
+      children[astToken.value].props = { ...children[astToken.value].props, ...props };
+    } else {
+      const moduleIdentifier = imports[astToken.value].importPath;
+      const name = imports[astToken.value].importName;
+      const filePath = ASTParser.validateFilePath(
+        path.resolve(path.dirname(parent.filePath), moduleIdentifier)
+      );
+      // Add tree node to childNodes if one does not exist
+      children[astToken.value] = {
+        id: getNonce(),
+        name,
+        fileName: path.basename(filePath),
+        filePath,
+        importPath: moduleIdentifier,
+        expanded: false,
+        depth: parent.depth + 1,
+        thirdParty: false,
+        reactRouter: false,
+        reduxConnect: false,
+        count: 1,
+        props,
+        children: [],
+        parentList: [parent.filePath].concat(parent.parentList),
+        error: '',
+      };
+    }
+    return children;
+  },
+
+  // Finds JSX React Components in current file
+  getJSXChildren(
+    astTokens: Array<Token>,
+    imports: Record<string, ImportData>,
+    parentNode: Tree
+  ): Array<Tree> {
+    let childNodes: Record<string, Tree> = {};
+    let props: Record<string, boolean> = {};
+    let token: Token;
+
+    for (let i = 0; i < astTokens.length; i++) {
+      // Case for finding JSX tags eg <App .../>
+      if (
+        astTokens[i].type.label === 'jsxTagStart' &&
+        astTokens[i + 1].type.label === 'jsxName' &&
+        imports[astTokens[i + 1].value]
+      ) {
+        token = astTokens[i + 1];
+        props = ASTParser.getJSXProps(astTokens, i + 2);
+        childNodes = ASTParser.getChildNodes(imports, token, props, parentNode, childNodes);
+
+        // Case for finding components passed in as props e.g. <Route component={App} />
+      } else if (
+        astTokens[i].type.label === 'jsxName' &&
+        (astTokens[i].value === 'component' || astTokens[i].value === 'children') &&
+        imports[astTokens[i + 3].value]
+      ) {
+        token = astTokens[i + 3];
+        childNodes = ASTParser.getChildNodes(imports, token, props, parentNode, childNodes);
+      }
+    }
+
+    return Object.values(childNodes);
+  },
+
+  // Extracts prop names from a JSX element
+  getJSXProps(astTokens: Array<Token>, j: number): Record<string, boolean> {
+    const props: Record<string, boolean> = {};
+    while (astTokens[j].type.label !== 'jsxTagEnd') {
+      if (astTokens[j].type.label === 'jsxName' && astTokens[j + 1].value === '=') {
+        props[astTokens[j].value] = true;
+      }
+      j += 1;
+    }
+    return props;
+  },
+
+  // Checks if current Node is connected to React-Redux Store
+  checkForRedux(astTokens: Array<Token>, imports: Record<string, ImportData>): boolean {
+    // Check that react-redux is imported in this file (and we have a connect method or otherwise)
+    let reduxImported = false;
+    let connectAlias;
+    Object.keys(imports).forEach((key) => {
+      if (imports[key].importPath === 'react-redux' && imports[key].importName === 'connect') {
+        reduxImported = true;
+        connectAlias = key;
+      }
+    });
+
+    if (!reduxImported) {
+      return false;
+    }
+
+    // Check that connect method is invoked and exported in the file
+    for (let i = 0; i < astTokens.length; i += 1) {
+      if (
+        astTokens[i].type.label === 'export' &&
+        astTokens[i + 1].type.label === 'default' &&
+        astTokens[i + 2].value === connectAlias
+      ) {
+        return true;
+      }
+    }
+    return false;
+  },
+};
+
+const ImportParser = {
   /* Extracts Imports from current file
    * https://github.com/babel/babel/blob/main/packages/babel-parser/ast/spec.md
    * https://github.com/babel/babel/blob/main/packages/babel-types/src/ast-types/generated/index.ts
    */
-  private getImports(body: Array<ASTNode>): Record<string, ImportData> {
+  parse(body: Array<ASTNode>): Record<string, ImportData> {
     return body
       .filter((astNode) => isImportDeclaration(astNode) || isVariableDeclaration(astNode))
       .reduce((accum: Record<string, ImportData>, declaration) => {
         return isImportDeclaration(declaration)
-          ? Object.assign(accum, this.parseImportDeclaration(declaration))
+          ? Object.assign(accum, ImportParser.parseImportDeclaration(declaration))
           : isVariableDeclaration(declaration)
-          ? Object.assign(accum, this.parseVariableDeclaration(declaration))
+          ? Object.assign(accum, ImportParser.parseVariableDeclaration(declaration))
           : accum;
       }, {});
-  }
+  },
 
   /* Import Declarations: 
    * e.g. import foo from "mod"
    '.source': name/path of imported module
    https://github.com/babel/babel/blob/main/packages/babel-parser/ast/spec.md#Imports
    */
-  private parseImportDeclaration(declaration: ImportDeclaration): Record<string, ImportData> {
+  parseImportDeclaration(declaration: ImportDeclaration): Record<string, ImportData> {
     const output: Record<string, ImportData> = {};
     let importName = '';
     let importAlias: string | undefined;
@@ -291,7 +425,7 @@ export class SaplingParser {
       };
     });
     return output;
-  }
+  },
 
   /* Imports Inside Variable Declarations (and current support status): 
    * [x] e.g. const foo = require("module");
@@ -303,7 +437,7 @@ export class SaplingParser {
    * [v] e.g. const foo = React.lazy(() => import('./module'));
    https://github.com/babel/babel/blob/main/packages/babel-parser/ast/spec.md#VariableDeclaration
    */
-  private parseVariableDeclaration(declaration: VariableDeclaration): Record<string, ImportData> {
+  parseVariableDeclaration(declaration: VariableDeclaration): Record<string, ImportData> {
     const output: Record<string, ImportData> = {};
     let importName = '';
     let importAlias: string | undefined;
@@ -377,7 +511,7 @@ export class SaplingParser {
       /* React lazy loading import
        * e.g. const foo = React.lazy(() => import('./module'));
        */
-      importPath = this.parseNestedDynamicImports(declarator);
+      importPath = ImportParser.parseNestedDynamicImports(declarator);
       if (importPath.length && isIdentifier(declarator.id)) {
         importName = declarator.id.name;
         output[importAlias || importName] = {
@@ -388,11 +522,11 @@ export class SaplingParser {
       }
     });
     return output;
-  }
+  },
 
   // TODO: Explicit parsing of nested Import CallExpression in ArrowFunctionExpression body
   // TODO: Support AwaitExpression, Promise.resolve(), then() chains for dynamic imports
-  private parseNestedDynamicImports(ast: ASTNode): string {
+  parseNestedDynamicImports(ast: ASTNode): string {
     const recurse = (node: ASTNode): string | void => {
       if (isCallExpression(node) && isImport(node.callee) && isStringLiteral(node.arguments[0])) {
         return node.arguments[0].value;
@@ -408,135 +542,11 @@ export class SaplingParser {
       }
     };
     return recurse(ast) || '';
-  }
+  },
+};
 
-  private validateFilePath(filePath: string): string {
-    const fileArray: string[] = [];
-    let parsedFileName = '';
-    // Handles Next.js component and other third-party imports
-    try {
-      fileArray.push(...fs.readdirSync(path.dirname(filePath)));
-    } catch {
-      return filePath;
-    }
-    // Checks that file exists and appends file extension to path if not given in import declaration
-    parsedFileName =
-      fileArray.find((str) => new RegExp(`${path.basename(filePath)}\\.[jt]sx?$`).test(str)) || '';
-    if (parsedFileName.length) return filePath + path.extname(parsedFileName);
-    return filePath;
-  }
-
-  private getChildNodes(
-    imports: Record<string, ImportData>,
-    astToken: Token,
-    props: Record<string, boolean>,
-    parent: Tree,
-    children: Record<string, Tree>
-  ): Record<string, Tree> {
-    if (children[astToken.value]) {
-      children[astToken.value].count += 1;
-      children[astToken.value].props = { ...children[astToken.value].props, ...props };
-    } else {
-      const moduleIdentifier = imports[astToken.value].importPath;
-      const name = imports[astToken.value].importName;
-      const filePath = this.validateFilePath(
-        path.resolve(path.dirname(parent.filePath), moduleIdentifier)
-      );
-      // Add tree node to childNodes if one does not exist
-      children[astToken.value] = {
-        id: getNonce(),
-        name,
-        fileName: path.basename(filePath),
-        filePath,
-        importPath: moduleIdentifier,
-        expanded: false,
-        depth: parent.depth + 1,
-        thirdParty: false,
-        reactRouter: false,
-        reduxConnect: false,
-        count: 1,
-        props,
-        children: [],
-        parentList: [parent.filePath].concat(parent.parentList),
-        error: '',
-      };
-    }
-    return children;
-  }
-
-  // Finds JSX React Components in current file
-  private getJSXChildren(
-    astTokens: Array<Token>,
-    imports: Record<string, ImportData>,
-    parentNode: Tree
-  ): Array<Tree> {
-    let childNodes: Record<string, Tree> = {};
-    let props: Record<string, boolean> = {};
-    let token: Token;
-
-    for (let i = 0; i < astTokens.length; i++) {
-      // Case for finding JSX tags eg <App .../>
-      if (
-        astTokens[i].type.label === 'jsxTagStart' &&
-        astTokens[i + 1].type.label === 'jsxName' &&
-        imports[astTokens[i + 1].value]
-      ) {
-        token = astTokens[i + 1];
-        props = this.getJSXProps(astTokens, i + 2);
-        childNodes = this.getChildNodes(imports, token, props, parentNode, childNodes);
-
-        // Case for finding components passed in as props e.g. <Route component={App} />
-      } else if (
-        astTokens[i].type.label === 'jsxName' &&
-        (astTokens[i].value === 'component' || astTokens[i].value === 'children') &&
-        imports[astTokens[i + 3].value]
-      ) {
-        token = astTokens[i + 3];
-        childNodes = this.getChildNodes(imports, token, props, parentNode, childNodes);
-      }
-    }
-
-    return Object.values(childNodes);
-  }
-
-  // Extracts prop names from a JSX element
-  private getJSXProps(astTokens: Array<Token>, j: number): Record<string, boolean> {
-    const props: Record<string, boolean> = {};
-    while (astTokens[j].type.label !== 'jsxTagEnd') {
-      if (astTokens[j].type.label === 'jsxName' && astTokens[j + 1].value === '=') {
-        props[astTokens[j].value] = true;
-      }
-      j += 1;
-    }
-    return props;
-  }
-
-  // Checks if current Node is connected to React-Redux Store
-  private checkForRedux(astTokens: Array<Token>, imports: Record<string, ImportData>): boolean {
-    // Check that react-redux is imported in this file (and we have a connect method or otherwise)
-    let reduxImported = false;
-    let connectAlias;
-    Object.keys(imports).forEach((key) => {
-      if (imports[key].importPath === 'react-redux' && imports[key].importName === 'connect') {
-        reduxImported = true;
-        connectAlias = key;
-      }
-    });
-
-    if (!reduxImported) {
-      return false;
-    }
-
-    // Check that connect method is invoked and exported in the file
-    for (let i = 0; i < astTokens.length; i += 1) {
-      if (
-        astTokens[i].type.label === 'export' &&
-        astTokens[i + 1].type.label === 'default' &&
-        astTokens[i + 2].value === connectAlias
-      ) {
-        return true;
-      }
-    }
-    return false;
-  }
-}
+// TODO: Follow import source paths and parse Export{Named,Default,All}Declarations
+// See: https://github.com/babel/babel/blob/main/packages/babel-parser/ast/spec.md#exports
+// Necessary for handling...
+// barrel files, namespace imports, default import + namespace/named imports, require invocations/method calls, ...
+const ExportParser = {};

--- a/sapling/src/SidebarProvider.ts
+++ b/sapling/src/SidebarProvider.ts
@@ -3,10 +3,9 @@
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
 // eslint-disable-next-line import/no-unresolved
 import * as vscode from 'vscode';
-import * as vscode from "vscode";
-import { getNonce } from "./getNonce";
+import { getNonce } from './helpers/getNonce';
 import { SaplingParser } from './SaplingParser';
-import { Tree } from "./types/Tree";
+import { Tree } from './types';
 
 // Sidebar class that creates a new instance of the sidebar + adds functionality with the parser
 export class SidebarProvider implements vscode.WebviewViewProvider {

--- a/sapling/src/SidebarProvider.ts
+++ b/sapling/src/SidebarProvider.ts
@@ -62,7 +62,7 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
         return;
       }
       // Post a message to the webview with the newly parsed tree
-      this.parser.updateTree(document.fileName);
+      this.tree.updateOnSave(document.fileName);
       await this.updateView();
     });
 
@@ -129,7 +129,7 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
           // let the parser know that the specific node clicked changed it's expanded value, save in state
           await this.context.workspaceState.update(
             'sapling',
-            this.parser.toggleNode(data.value.id, data.value.expandedState)
+            this.tree.findAndToggleExpanded(data.value.id, data.value.expandedState)
           );
           break;
         }

--- a/sapling/src/SidebarProvider.ts
+++ b/sapling/src/SidebarProvider.ts
@@ -136,11 +136,9 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
           if (!this.tree) {
             return;
           }
+          this.tree.findAndToggleExpanded(data.value.id);
           // let the parser know that the specific node clicked changed it's expanded value, save in state
-          await this.context.workspaceState.update(
-            'sapling',
-            this.tree.findAndToggleExpanded(data.value.id, data.value.expandedState)
-          );
+          await this.updateView();
           break;
         }
 

--- a/sapling/src/SidebarProvider.ts
+++ b/sapling/src/SidebarProvider.ts
@@ -187,11 +187,6 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
     }
   };
 
-  // revive statement for the webview panel
-  public revive(panel: vscode.WebviewView): void {
-    this._view = panel;
-  }
-
   // Helper method to send updated tree data to view, and saves current tree to workspace
   private async updateView() {
     // If parser or webview do not exist, do nothing

--- a/sapling/src/SidebarProvider.ts
+++ b/sapling/src/SidebarProvider.ts
@@ -75,24 +75,22 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
       // Switch cases based on the type sent as a message
       switch (data.type) {
         // Case when the user selects a file to begin a tree
-        case "onFile": {
+        case 'onFile': {
           // open vscode dialog selector
-          vscode.window.showOpenDialog({canSelectMany: false, canSelectFolders: false})
-            .then( uri => {
-            
-            // Edge case if selector doesn't work
-            if (!(uri && uri[0])) {
-              return;
-            }
-
-            // convert uri to path string
-            const filePath = uri[0].fsPath;
-
-            // Run an instance of the parser
-            this.parser = new SaplingParser(filePath);
-            this.parser.parse();
-            this.updateView();
-            });
+          const uri = await vscode.window.showOpenDialog({
+            canSelectMany: false,
+            canSelectFolders: false,
+          });
+          // Edge case if selector doesn't work
+          if (!uri || !uri[0]) {
+            return;
+          }
+          // convert uri to path string
+          const filePath = uri[0].fsPath;
+          // Run an instance of the parser
+          this.parser = new SaplingParser(filePath);
+          this.parser.parse();
+          await this.updateView();
           break;
         }
 

--- a/sapling/src/SidebarProvider.ts
+++ b/sapling/src/SidebarProvider.ts
@@ -19,10 +19,7 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
     this.context = context;
     this._extensionUri = context.extensionUri;
     // Check for sapling state in workspace and set tree with previous state
-    const state: Tree | undefined = context.workspaceState.get('sapling');
-    if (state) {
-      this.tree = SaplingParser.parse(state.filePath);
-    }
+    this.tree = context.workspaceState.get('sapling');
   }
 
   // Instantiate the connection to the webview
@@ -74,11 +71,12 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
       // Switch cases based on the type sent as a message
       switch (data.type) {
         // Case when the user selects a file to begin a tree
-        case "onFile": {
+        case 'onFile': {
           // open vscode dialog selector
-          vscode.window.showOpenDialog({canSelectMany: false, canSelectFolders: false})
-            .then( uri => {
-            
+          const uri = await vscode.window.showOpenDialog({
+            canSelectMany: false,
+            canSelectFolders: false,
+          });
             // Edge case if selector doesn't work
             if (!(uri && uri[0])) {
               return;
@@ -86,12 +84,9 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
 
             // convert uri to path string
             const filePath = uri[0].fsPath;
-
-            // Run an instance of the parser
-            this.parser = new SaplingParser(filePath);
-            this.parser.parse();
-            this.updateView();
-            });
+          // Generate tree with SaplingParser
+          this.tree = SaplingParser.parse(filePath);
+          await this.updateView();
           break;
         }
 

--- a/sapling/src/SidebarProvider.ts
+++ b/sapling/src/SidebarProvider.ts
@@ -131,7 +131,7 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
           // let the parser know that the specific node clicked changed it's expanded value, save in state
           await this.context.workspaceState.update(
             'sapling',
-            this.parser.toggleNode(data.value.id, data.value.expanded)
+            this.parser.toggleNode(data.value.id, data.value.expandedState)
           );
           break;
         }

--- a/sapling/src/extension.ts
+++ b/sapling/src/extension.ts
@@ -1,15 +1,14 @@
+// eslint-disable-next-line import/no-unresolved
 import * as vscode from 'vscode';
 import { SidebarProvider } from './SidebarProvider';
 
 // Sapling extension is activated after vscode startup
-export function activate(context: vscode.ExtensionContext) {
+export function activate(context: vscode.ExtensionContext): void {
   // instantiating the sidebar webview
   const sidebarProvider = new SidebarProvider(context);
 
   // Create Build Tree Status Bar Button
-  const item = vscode.window.createStatusBarItem(
-    vscode.StatusBarAlignment.Right
-  );
+  const item = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right);
   item.tooltip = 'Generate hierarchy tree from current file';
   item.text = '$(list-tree) Build Tree';
   item.command = 'sapling.generateTree';
@@ -17,17 +16,14 @@ export function activate(context: vscode.ExtensionContext) {
 
   // Register Sapling Sidebar Webview View
   context.subscriptions.push(
-    vscode.window.registerWebviewViewProvider(
-      "sapling-sidebar",
-      sidebarProvider
-    )
+    vscode.window.registerWebviewViewProvider('sapling-sidebar', sidebarProvider)
   );
 
   // Register command to generate tree from current file on status button click or from explorer context
   context.subscriptions.push(
-    vscode.commands.registerCommand("sapling.generateTree", async (uri: vscode.Uri | undefined) => {
+    vscode.commands.registerCommand('sapling.generateTree', async (uri: vscode.Uri | undefined) => {
       await vscode.commands.executeCommand('workbench.view.extension.sapling-sidebar-view');
-      sidebarProvider.statusButtonClicked(uri);
+      await sidebarProvider.statusButtonClicked(uri);
     })
   );
 
@@ -47,4 +43,4 @@ export function activate(context: vscode.ExtensionContext) {
 }
 
 // this method is called when your extension is deactivated
-export function deactivate() {}
+export function deactivate(): void {}

--- a/sapling/src/getNonce.ts
+++ b/sapling/src/getNonce.ts
@@ -1,9 +1,0 @@
-export function getNonce() : string {
-  let text : string = "";
-  const possible : string =
-    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
-  for (let i = 0; i < 32; i++) {
-    text += possible.charAt(Math.floor(Math.random() * possible.length));
-  }
-  return text;
-}

--- a/sapling/src/helpers/getNonce.ts
+++ b/sapling/src/helpers/getNonce.ts
@@ -1,0 +1,9 @@
+const VALID_CHARACTERS: string = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+const NONCE_LENGTH: number = 32;
+
+export function getNonce(): string {
+  const nonce = new Array(NONCE_LENGTH).fill('0');
+  return nonce
+    .map(() => VALID_CHARACTERS.charAt(Math.floor(Math.random() * VALID_CHARACTERS.length)))
+    .join('');
+}

--- a/sapling/src/test/suite/parser.test.ts
+++ b/sapling/src/test/suite/parser.test.ts
@@ -43,9 +43,9 @@ suite('Parser Test Suite', () => {
     });
 
     test('Parsed tree has a property called name with value index and one child with name App', () => {
-      expect(tree).to.have.own.property('name').that.is.equal('index');
-      expect(tree).to.have.own.property('children').that.is.an('array');
-      expect(tree.get(0)).to.have.own.property('name').that.is.equal('App');
+      expect(tree.name).that.is.equal('index');
+      expect(tree.children).that.is.an('array');
+      expect(tree.get(0).name).that.is.equal('App');
     });
   });
 
@@ -57,10 +57,10 @@ suite('Parser Test Suite', () => {
     });
 
     test('Parsed tree has a property called name with value index and one child with name App, which has its own child Main', () => {
-      expect(tree).to.have.own.property('name').to.equal('index');
-      expect(tree.get(0)).to.have.own.property('name').to.equal('App');
-      expect(tree.get(0)).to.have.own.property('children').that.is.an('array');
-      expect(tree.get(0, 0)).to.have.own.property('name').to.equal('Main');
+      expect(tree.name).to.equal('index');
+      expect(tree.get(0).name).to.equal('App');
+      expect(tree.get(0).children).that.is.an('array');
+      expect(tree.get(0, 0).name).to.equal('Main');
     });
 
     test('Parsed tree children should equal the child components', () => {
@@ -69,9 +69,9 @@ suite('Parser Test Suite', () => {
     });
 
     test('Parsed tree depth is accurate', () => {
-      expect(tree).to.have.own.property('depth').that.is.equal(0);
-      expect(tree.get(0)).to.have.own.property('depth').that.is.equal(1);
-      expect(tree.get(0, 0)).to.have.own.property('depth').that.is.equal(2);
+      expect(tree.depth).that.is.equal(0);
+      expect(tree.get(0).depth).that.is.equal(1);
+      expect(tree.get(0, 0).depth).that.is.equal(2);
     });
   });
 
@@ -84,22 +84,22 @@ suite('Parser Test Suite', () => {
 
     test('Should parse destructured and third party imports', () => {
       expect(tree.children).to.have.lengthOf(3);
-      expect(tree.get(0)).to.have.own.property('name').that.is.oneOf(['Switch', 'Route']);
-      expect(tree.get(1)).to.have.own.property('name').that.is.oneOf(['Switch', 'Route']);
-      expect(tree.get(2)).to.have.own.property('name').that.is.equal('Tippy');
+      expect(tree.get(0).name).that.is.oneOf(['Switch', 'Route']);
+      expect(tree.get(1).name).that.is.oneOf(['Switch', 'Route']);
+      expect(tree.get(2).name).that.is.equal('Tippy');
     });
 
     test('React router should be designated as third party and isReactRouter', () => {
-      expect(tree.get(0)).to.have.own.property('isThirdParty').to.be.true;
-      expect(tree.get(1)).to.have.own.property('isThirdParty').to.be.true;
+      expect(tree.get(0).isThirdParty).to.be.true;
+      expect(tree.get(1).isThirdParty).to.be.true;
 
-      expect(tree.get(0)).to.have.own.property('isReactRouter').to.be.true;
-      expect(tree.get(1)).to.have.own.property('isReactRouter').to.be.true;
+      expect(tree.get(0).isReactRouter).to.be.true;
+      expect(tree.get(1).isReactRouter).to.be.true;
     });
 
     test('Tippy should be designated as third party and not isReactRouter', () => {
-      expect(tree.get(2)).to.have.own.property('isThirdParty').to.be.true;
-      expect(tree.get(2)).to.have.own.property('isReactRouter').to.be.false;
+      expect(tree.get(2).isThirdParty).to.be.true;
+      expect(tree.get(2).isReactRouter).to.be.false;
     });
   });
 
@@ -112,10 +112,10 @@ suite('Parser Test Suite', () => {
 
     test('The hasReduxConnect properties of the connected component and the unconnected component should be true and false, respectively', () => {
       expect(tree.get(1, 0).name).to.equal('ConnectedContainer');
-      expect(tree.get(1, 0)).to.have.own.property('hasReduxConnect').that.is.true;
+      expect(tree.get(1, 0).hasReduxConnect).that.is.true;
 
       expect(tree.get(1, 1).name).to.equal('UnconnectedContainer');
-      expect(tree.get(1, 1)).to.have.own.property('hasReduxConnect').that.is.false;
+      expect(tree.get(1, 1).hasReduxConnect).that.is.false;
     });
   });
 
@@ -128,11 +128,11 @@ suite('Parser Test Suite', () => {
 
     test('alias should still give us components', () => {
       expect(tree.children).to.have.lengthOf(2);
-      expect(tree.get(0)).to.have.own.property('name').that.is.equal('Switch');
-      expect(tree.get(1)).to.have.own.property('name').that.is.equal('Route');
+      expect(tree.get(0).name).that.is.equal('Switch');
+      expect(tree.get(1).name).that.is.equal('Route');
 
-      expect(tree.get(0)).to.have.own.property('name').that.is.not.equal('S');
-      expect(tree.get(1)).to.have.own.property('name').that.is.not.equal('R');
+      expect(tree.get(0).name).that.is.not.equal('S');
+      expect(tree.get(1).name).that.is.not.equal('R');
     });
   });
 
@@ -179,8 +179,8 @@ suite('Parser Test Suite', () => {
     });
 
     test('improperly imported child component should exist but show an error', () => {
-      expect(tree.get(0, 0)).to.have.own.property('name').that.equals('App2');
-      expect(tree.get(0, 0)).to.have.own.property('error').that.does.not.equal('');
+      expect(tree.get(0, 0).name).that.equals('App2');
+      expect(tree.get(0, 0).error).that.does.not.equal('');
     });
   });
 
@@ -192,8 +192,8 @@ suite('Parser Test Suite', () => {
     });
 
     test('Should have a nonempty error message on the invalid child and not parse further', () => {
-      expect(tree.get(0)).to.have.own.property('name').that.equals('App');
-      expect(tree.get(0)).to.have.own.property('error').that.does.not.equal('');
+      expect(tree.get(0).name).that.equals('App');
+      expect(tree.get(0).error).that.does.not.equal('');
       expect(tree.get(0).children).to.have.lengthOf(0);
     });
   });
@@ -206,7 +206,7 @@ suite('Parser Test Suite', () => {
     });
 
     test('Grandchild should have a count of 1', () => {
-      expect(tree.get(0, 0)).to.have.own.property('count').that.equals(1);
+      expect(tree.get(0, 0).count).that.equals(1);
     });
 
     test('Grandchild should have the correct three props', () => {
@@ -224,7 +224,7 @@ suite('Parser Test Suite', () => {
     });
 
     test('Grandchild should have a count of 2', () => {
-      expect(tree.get(0, 0)).to.have.own.property('count').that.equals(2);
+      expect(tree.get(0, 0).count).that.equals(2);
     });
 
     test('Grandchild should have the correct two props', () => {
@@ -241,11 +241,11 @@ suite('Parser Test Suite', () => {
     });
 
     test('Parent should have children that match the value stored in component prop', () => {
-      expect(tree.get(0)).to.have.own.property('name').that.is.equal('BrowserRouter');
-      expect(tree.get(1)).to.have.own.property('name').that.is.equal('App');
+      expect(tree.get(0).name).that.is.equal('BrowserRouter');
+      expect(tree.get(1).name).that.is.equal('App');
 
-      expect(tree.get(1, 3)).to.have.own.property('name').that.is.equal('DrillCreator');
-      expect(tree.get(1, 4)).to.have.own.property('name').that.is.equal('HistoryDisplay');
+      expect(tree.get(1, 3).name).that.is.equal('DrillCreator');
+      expect(tree.get(1, 4).name).that.is.equal('HistoryDisplay');
     });
   });
 
@@ -261,13 +261,13 @@ suite('Parser Test Suite', () => {
     });
 
     test('Tree should have an index component while child App1, grandchild App2, great-grandchild App1', () => {
-      expect(tree).to.have.own.property('name').that.is.equal('index');
+      expect(tree.name).that.is.equal('index');
       expect(tree.children).to.have.lengthOf(1);
-      expect(tree.get(0)).to.have.own.property('name').that.is.equal('App1');
+      expect(tree.get(0).name).that.is.equal('App1');
       expect(tree.get(0).children).to.have.lengthOf(1);
-      expect(tree.get(0, 0)).to.have.own.property('name').that.is.equal('App2');
+      expect(tree.get(0, 0).name).that.is.equal('App2');
       expect(tree.get(0, 0).children).to.have.lengthOf(1);
-      expect(tree.get(0, 0, 0)).to.have.own.property('name').that.is.equal('App1');
+      expect(tree.get(0, 0, 0).name).that.is.equal('App1');
       expect(tree.get(0, 0, 0).children).to.have.lengthOf(0);
     });
   });
@@ -280,15 +280,15 @@ suite('Parser Test Suite', () => {
     });
 
     test('Root should be named index, children should be named Head, Navbar, and Image, children of Navbar should be named Link and Image', () => {
-      expect(tree).to.have.own.property('name').that.is.equal('index');
+      expect(tree.name).that.is.equal('index');
       expect(tree.children).to.have.lengthOf(3);
-      expect(tree.get(0)).to.have.own.property('name').that.is.equal('Head');
-      expect(tree.get(1)).to.have.own.property('name').that.is.equal('Navbar');
-      expect(tree.get(2)).to.have.own.property('name').that.is.equal('Image');
+      expect(tree.get(0).name).that.is.equal('Head');
+      expect(tree.get(1).name).that.is.equal('Navbar');
+      expect(tree.get(2).name).that.is.equal('Image');
 
       expect(tree.get(1).children).to.have.lengthOf(2);
-      expect(tree.get(1, 0)).to.have.own.property('name').that.is.equal('Link');
-      expect(tree.get(1, 1)).to.have.own.property('name').that.is.equal('Image');
+      expect(tree.get(1, 0).name).that.is.equal('Link');
+      expect(tree.get(1, 1).name).that.is.equal('Image');
     });
   });
 
@@ -300,16 +300,16 @@ suite('Parser Test Suite', () => {
     });
 
     test('Root should be named index, it should have one child named App', () => {
-      expect(tree).to.have.own.property('name').that.is.equal('index');
+      expect(tree.name).that.is.equal('index');
       expect(tree.children).to.have.lengthOf(1);
-      expect(tree.get(0)).to.have.own.property('name').that.is.equal('App');
+      expect(tree.get(0).name).that.is.equal('App');
     });
 
     test('App should have three children, Page1, Page2 and Page3, all found successfully', () => {
-      expect(tree.get(0, 0)).to.have.own.property('name').that.is.equal('Page1');
-      expect(tree.get(0, 0)).to.have.own.property('isThirdParty').that.is.false;
-      expect(tree.get(0, 1)).to.have.own.property('name').that.is.equal('Page2');
-      expect(tree.get(0, 1)).to.have.own.property('isThirdParty').that.is.false;
+      expect(tree.get(0, 0).name).that.is.equal('Page1');
+      expect(tree.get(0, 0).isThirdParty).that.is.false;
+      expect(tree.get(0, 1).name).that.is.equal('Page2');
+      expect(tree.get(0, 1).isThirdParty).that.is.false;
     });
   });
 
@@ -321,23 +321,23 @@ suite('Parser Test Suite', () => {
     });
 
     test('Root should be named index, it should have one child named App', () => {
-      expect(tree).to.have.own.property('name').that.is.equal('index');
+      expect(tree.name).that.is.equal('index');
       expect(tree.children).to.have.lengthOf(1);
-      expect(tree.get(0)).to.have.own.property('name').that.is.equal('App');
+      expect(tree.get(0).name).that.is.equal('App');
     });
 
     test('Object destructured children PageA1, PageA2 successfully found. PageA1 is found with its filename, not as Alias.', () => {
-      expect(tree.get(0, 0)).to.have.own.property('name').that.is.not.equal('Alias');
-      expect(tree.get(0, 0)).to.have.own.property('name').that.is.equal('PageA1');
-      expect(tree.get(0, 0)).to.have.own.property('isThirdParty').that.is.false;
-      expect(tree.get(0, 1)).to.have.own.property('name').that.is.equal('PageA2');
-      expect(tree.get(0, 1)).to.have.own.property('isThirdParty').that.is.false;
+      expect(tree.get(0, 0).name).that.is.not.equal('Alias');
+      expect(tree.get(0, 0).name).that.is.equal('PageA1');
+      expect(tree.get(0, 0).isThirdParty).that.is.false;
+      expect(tree.get(0, 1).name).that.is.equal('PageA2');
+      expect(tree.get(0, 1).isThirdParty).that.is.false;
     });
     test('Array destructured require import PageB1, PageB2 all found successfully', () => {
-      expect(tree.get(0, 2)).to.have.own.property('name').that.is.equal('PageB1');
-      expect(tree.get(0, 2)).to.have.own.property('isThirdParty').that.is.false;
-      expect(tree.get(0, 3)).to.have.own.property('name').that.is.equal('PageB2');
-      expect(tree.get(0, 3)).to.have.own.property('isThirdParty').that.is.false;
+      expect(tree.get(0, 2).name).that.is.equal('PageB1');
+      expect(tree.get(0, 2).isThirdParty).that.is.false;
+      expect(tree.get(0, 3).name).that.is.equal('PageB2');
+      expect(tree.get(0, 3).isThirdParty).that.is.false;
     });
   });
 
@@ -349,23 +349,23 @@ suite('Parser Test Suite', () => {
     });
 
     test('Root should be named index, it should have one child named App', () => {
-      expect(tree).to.have.own.property('name').that.is.equal('index');
+      expect(tree.name).that.is.equal('index');
       expect(tree.children).to.have.lengthOf(1);
-      expect(tree.get(0)).to.have.own.property('name').that.is.equal('App');
+      expect(tree.get(0).name).that.is.equal('App');
     });
 
     test('Object destructured children PageA1, PageA2 successfully found. PageA1 is found with its filename, not as Alias.', () => {
-      expect(tree.get(0, 0)).to.have.own.property('name').that.is.not.equal('Alias');
-      expect(tree.get(0, 0)).to.have.own.property('name').that.is.equal('PageA1');
-      expect(tree.get(0, 0)).to.have.own.property('isThirdParty').that.is.false;
-      expect(tree.get(0, 1)).to.have.own.property('name').that.is.equal('PageA2');
-      expect(tree.get(0, 1)).to.have.own.property('isThirdParty').that.is.false;
+      expect(tree.get(0, 0).name).that.is.not.equal('Alias');
+      expect(tree.get(0, 0).name).that.is.equal('PageA1');
+      expect(tree.get(0, 0).isThirdParty).that.is.false;
+      expect(tree.get(0, 1).name).that.is.equal('PageA2');
+      expect(tree.get(0, 1).isThirdParty).that.is.false;
     });
     test('Array destructured children PageB1, PageB2 all found successfully', () => {
-      expect(tree.get(0, 2)).to.have.own.property('name').that.is.equal('PageB1');
-      expect(tree.get(0, 2)).to.have.own.property('isThirdParty').that.is.false;
-      expect(tree.get(0, 3)).to.have.own.property('name').that.is.equal('PageB2');
-      expect(tree.get(0, 3)).to.have.own.property('isThirdParty').that.is.false;
+      expect(tree.get(0, 2).name).that.is.equal('PageB1');
+      expect(tree.get(0, 2).isThirdParty).that.is.false;
+      expect(tree.get(0, 3).name).that.is.equal('PageB2');
+      expect(tree.get(0, 3).isThirdParty).that.is.false;
     });
   });
 });

--- a/sapling/src/test/suite/parser.test.ts
+++ b/sapling/src/test/suite/parser.test.ts
@@ -1,5 +1,6 @@
 import * as path from 'path';
 import * as assert from 'assert';
+
 import { describe, suite, test, before } from 'mocha';
 import { expect } from 'chai';
 
@@ -330,8 +331,64 @@ suite('Parser Test Suite', () => {
       expect(tree.children[0].children[0]).to.have.own.property('thirdParty').that.is.false;
       expect(tree.children[0].children[1]).to.have.own.property('name').that.is.equal('Page2');
       expect(tree.children[0].children[1]).to.have.own.property('thirdParty').that.is.false;
-      expect(tree.children[0].children[2]).to.have.own.property('name').that.is.equal('Page3');
+    });
+  });
+
+  // TEST 14: REQUIRE STATEMENTS WITH DESTRUCTURING, ALIASING
+  describe('It should parse require function calls with destructuring and aliasing', () => {
+    before(() => {
+      file = path.join(__dirname, '../../../src/test/test_apps/test_14/index.js');
+      parser = new SaplingParser(file);
+      tree = parser.parse();
+    });
+
+    test('Root should be named index, it should have one child named App', () => {
+      expect(tree).to.have.own.property('name').that.is.equal('index');
+      expect(tree.children).to.have.lengthOf(1);
+      expect(tree.children[0]).to.have.own.property('name').that.is.equal('App');
+    });
+
+    test('Object destructured children PageA1, PageA2 successfully found. PageA1 is found with its filename, not as Alias.', () => {
+      expect(tree.children[0].children[0]).to.have.own.property('name').that.is.not.equal('Alias');
+      expect(tree.children[0].children[0]).to.have.own.property('name').that.is.equal('PageA1');
+      expect(tree.children[0].children[0]).to.have.own.property('thirdParty').that.is.false;
+      expect(tree.children[0].children[1]).to.have.own.property('name').that.is.equal('PageA2');
+      expect(tree.children[0].children[1]).to.have.own.property('thirdParty').that.is.false;
+    });
+    test('Array destructured require import PageB1, PageB2 all found successfully', () => {
+      expect(tree.children[0].children[2]).to.have.own.property('name').that.is.equal('PageB1');
       expect(tree.children[0].children[2]).to.have.own.property('thirdParty').that.is.false;
+      expect(tree.children[0].children[3]).to.have.own.property('name').that.is.equal('PageB2');
+      expect(tree.children[0].children[3]).to.have.own.property('thirdParty').that.is.false;
+    });
+  });
+
+  // TEST 15: VARIABLE DECLARATION IMPORTS WITH DESTRUCTURING, ALIASING
+  describe('It should parse variable declaration imports with Array Destructuring, and Object Destructuring with Aliasing', () => {
+    before(() => {
+      file = path.join(__dirname, '../../../src/test/test_apps/test_15/index.js');
+      parser = new SaplingParser(file);
+      tree = parser.parse();
+    });
+
+    test('Root should be named index, it should have one child named App', () => {
+      expect(tree).to.have.own.property('name').that.is.equal('index');
+      expect(tree.children).to.have.lengthOf(1);
+      expect(tree.children[0]).to.have.own.property('name').that.is.equal('App');
+    });
+
+    test('Object destructured children PageA1, PageA2 successfully found. PageA1 is found with its filename, not as Alias.', () => {
+      expect(tree.children[0].children[0]).to.have.own.property('name').that.is.not.equal('Alias');
+      expect(tree.children[0].children[0]).to.have.own.property('name').that.is.equal('PageA1');
+      expect(tree.children[0].children[0]).to.have.own.property('thirdParty').that.is.false;
+      expect(tree.children[0].children[1]).to.have.own.property('name').that.is.equal('PageA2');
+      expect(tree.children[0].children[1]).to.have.own.property('thirdParty').that.is.false;
+    });
+    test('Array destructured require import PageB1, PageB2 all found successfully', () => {
+      expect(tree.children[0].children[2]).to.have.own.property('name').that.is.equal('PageB1');
+      expect(tree.children[0].children[2]).to.have.own.property('thirdParty').that.is.false;
+      expect(tree.children[0].children[3]).to.have.own.property('name').that.is.equal('PageB2');
+      expect(tree.children[0].children[3]).to.have.own.property('thirdParty').that.is.false;
     });
   });
 });

--- a/sapling/src/test/suite/parser.test.ts
+++ b/sapling/src/test/suite/parser.test.ts
@@ -47,7 +47,7 @@ suite('Parser Test Suite', () => {
     test('Parsed tree has a property called name with value index and one child with name App', () => {
       expect(tree).to.have.own.property('name').that.is.equal('index');
       expect(tree).to.have.own.property('children').that.is.an('array');
-      expect(tree.children[0]).to.have.own.property('name').that.is.equal('App');
+      expect(tree.get(0)).to.have.own.property('name').that.is.equal('App');
     });
   });
 
@@ -61,20 +61,20 @@ suite('Parser Test Suite', () => {
 
     test('Parsed tree has a property called name with value index and one child with name App, which has its own child Main', () => {
       expect(tree).to.have.own.property('name').to.equal('index');
-      expect(tree.children[0].name).to.equal('App');
-      expect(tree.children[0]).to.have.own.property('children').that.is.an('array');
-      expect(tree.children[0].children[0]).to.have.own.property('name').to.equal('Main');
+      expect(tree.get(0)).to.have.own.property('name').to.equal('App');
+      expect(tree.get(0)).to.have.own.property('children').that.is.an('array');
+      expect(tree.get(0, 0)).to.have.own.property('name').to.equal('Main');
     });
 
     test('Parsed tree children should equal the child components', () => {
       expect(tree.children).to.have.lengthOf(1);
-      expect(tree.children[0].children).to.have.lengthOf(1);
+      expect(tree.get(0).children).to.have.lengthOf(1);
     });
 
     test('Parsed tree depth is accurate', () => {
       expect(tree).to.have.own.property('depth').that.is.equal(0);
-      expect(tree.children[0]).to.have.own.property('depth').that.is.equal(1);
-      expect(tree.children[0].children[0]).to.have.own.property('depth').that.is.equal(2);
+      expect(tree.get(0)).to.have.own.property('depth').that.is.equal(1);
+      expect(tree.get(0, 0)).to.have.own.property('depth').that.is.equal(2);
     });
   });
 
@@ -88,22 +88,22 @@ suite('Parser Test Suite', () => {
 
     test('Should parse destructured and third party imports', () => {
       expect(tree.children).to.have.lengthOf(3);
-      expect(tree.children[0]).to.have.own.property('name').that.is.oneOf(['Switch', 'Route']);
-      expect(tree.children[1]).to.have.own.property('name').that.is.oneOf(['Switch', 'Route']);
-      expect(tree.children[2]).to.have.own.property('name').that.is.equal('Tippy');
+      expect(tree.get(0)).to.have.own.property('name').that.is.oneOf(['Switch', 'Route']);
+      expect(tree.get(1)).to.have.own.property('name').that.is.oneOf(['Switch', 'Route']);
+      expect(tree.get(2)).to.have.own.property('name').that.is.equal('Tippy');
     });
 
-    test('reactRouter should be designated as third party and reactRouter', () => {
-      expect(tree.children[0]).to.have.own.property('thirdParty').to.be.true;
-      expect(tree.children[1]).to.have.own.property('thirdParty').to.be.true;
+    test('React router should be designated as third party and reactRouter', () => {
+      expect(tree.get(0)).to.have.own.property('thirdParty').to.be.true;
+      expect(tree.get(1)).to.have.own.property('thirdParty').to.be.true;
 
-      expect(tree.children[0]).to.have.own.property('reactRouter').to.be.true;
-      expect(tree.children[1]).to.have.own.property('reactRouter').to.be.true;
+      expect(tree.get(0)).to.have.own.property('reactRouter').to.be.true;
+      expect(tree.get(1)).to.have.own.property('reactRouter').to.be.true;
     });
 
     test('Tippy should be designated as third party and not reactRouter', () => {
-      expect(tree.children[2]).to.have.own.property('thirdParty').to.be.true;
-      expect(tree.children[2]).to.have.own.property('reactRouter').to.be.false;
+      expect(tree.get(2)).to.have.own.property('thirdParty').to.be.true;
+      expect(tree.get(2)).to.have.own.property('reactRouter').to.be.false;
     });
   });
 
@@ -116,11 +116,11 @@ suite('Parser Test Suite', () => {
     });
 
     test('The reduxConnect properties of the connected component and the unconnected component should be true and false, respectively', () => {
-      expect(tree.children[1].children[0].name).to.equal('ConnectedContainer');
-      expect(tree.children[1].children[0]).to.have.own.property('reduxConnect').that.is.true;
+      expect(tree.get(1, 0).name).to.equal('ConnectedContainer');
+      expect(tree.get(1, 0)).to.have.own.property('reduxConnect').that.is.true;
 
-      expect(tree.children[1].children[1].name).to.equal('UnconnectedContainer');
-      expect(tree.children[1].children[1]).to.have.own.property('reduxConnect').that.is.false;
+      expect(tree.get(1, 1).name).to.equal('UnconnectedContainer');
+      expect(tree.get(1, 1)).to.have.own.property('reduxConnect').that.is.false;
     });
   });
 
@@ -134,11 +134,11 @@ suite('Parser Test Suite', () => {
 
     test('alias should still give us components', () => {
       expect(tree.children).to.have.lengthOf(2);
-      expect(tree.children[0]).to.have.own.property('name').that.is.equal('Switch');
-      expect(tree.children[1]).to.have.own.property('name').that.is.equal('Route');
+      expect(tree.get(0)).to.have.own.property('name').that.is.equal('Switch');
+      expect(tree.get(1)).to.have.own.property('name').that.is.equal('Route');
 
-      expect(tree.children[0]).to.have.own.property('name').that.is.not.equal('S');
-      expect(tree.children[1]).to.have.own.property('name').that.is.not.equal('R');
+      expect(tree.get(0)).to.have.own.property('name').that.is.not.equal('S');
+      expect(tree.get(1)).to.have.own.property('name').that.is.not.equal('R');
     });
   });
 
@@ -187,8 +187,8 @@ suite('Parser Test Suite', () => {
     });
 
     test('improperly imported child component should exist but show an error', () => {
-      expect(tree.children[0].children[0]).to.have.own.property('name').that.equals('App2');
-      expect(tree.children[0].children[0]).to.have.own.property('error').that.does.not.equal('');
+      expect(tree.get(0, 0)).to.have.own.property('name').that.equals('App2');
+      expect(tree.get(0, 0)).to.have.own.property('error').that.does.not.equal('');
     });
   });
 
@@ -201,9 +201,9 @@ suite('Parser Test Suite', () => {
     });
 
     test('Should have a nonempty error message on the invalid child and not parse further', () => {
-      expect(tree.children[0]).to.have.own.property('name').that.equals('App');
-      expect(tree.children[0]).to.have.own.property('error').that.does.not.equal('');
-      expect(tree.children[0].children).to.have.lengthOf(0);
+      expect(tree.get(0)).to.have.own.property('name').that.equals('App');
+      expect(tree.get(0)).to.have.own.property('error').that.does.not.equal('');
+      expect(tree.get(0).children).to.have.lengthOf(0);
     });
   });
 
@@ -216,13 +216,13 @@ suite('Parser Test Suite', () => {
     });
 
     test('Grandchild should have a count of 1', () => {
-      expect(tree.children[0].children[0]).to.have.own.property('count').that.equals(1);
+      expect(tree.get(0, 0)).to.have.own.property('count').that.equals(1);
     });
 
     test('Grandchild should have the correct three props', () => {
-      expect(tree.children[0].children[0].props).has.own.property('prop1').that.is.true;
-      expect(tree.children[0].children[0].props).has.own.property('prop2').that.is.true;
-      expect(tree.children[0].children[0].props).has.own.property('prop3').that.is.true;
+      expect(tree.get(0, 0).props).has.own.property('prop1').that.is.true;
+      expect(tree.get(0, 0).props).has.own.property('prop2').that.is.true;
+      expect(tree.get(0, 0).props).has.own.property('prop3').that.is.true;
     });
   });
 
@@ -235,12 +235,12 @@ suite('Parser Test Suite', () => {
     });
 
     test('Grandchild should have a count of 2', () => {
-      expect(tree.children[0].children[0]).to.have.own.property('count').that.equals(2);
+      expect(tree.get(0, 0)).to.have.own.property('count').that.equals(2);
     });
 
     test('Grandchild should have the correct two props', () => {
-      expect(tree.children[0].children[0].props).has.own.property('prop1').that.is.true;
-      expect(tree.children[0].children[0].props).has.own.property('prop2').that.is.true;
+      expect(tree.get(0, 0).props).has.own.property('prop1').that.is.true;
+      expect(tree.get(0, 0).props).has.own.property('prop2').that.is.true;
     });
   });
 
@@ -253,15 +253,11 @@ suite('Parser Test Suite', () => {
     });
 
     test('Parent should have children that match the value stored in component prop', () => {
-      expect(tree.children[0]).to.have.own.property('name').that.is.equal('BrowserRouter');
-      expect(tree.children[1]).to.have.own.property('name').that.is.equal('App');
+      expect(tree.get(0)).to.have.own.property('name').that.is.equal('BrowserRouter');
+      expect(tree.get(1)).to.have.own.property('name').that.is.equal('App');
 
-      expect(tree.children[1].children[3])
-        .to.have.own.property('name')
-        .that.is.equal('DrillCreator');
-      expect(tree.children[1].children[4])
-        .to.have.own.property('name')
-        .that.is.equal('HistoryDisplay');
+      expect(tree.get(1, 3)).to.have.own.property('name').that.is.equal('DrillCreator');
+      expect(tree.get(1, 4)).to.have.own.property('name').that.is.equal('HistoryDisplay');
     });
   });
 
@@ -280,14 +276,12 @@ suite('Parser Test Suite', () => {
     test('Tree should have an index component while child App1, grandchild App2, great-grandchild App1', () => {
       expect(tree).to.have.own.property('name').that.is.equal('index');
       expect(tree.children).to.have.lengthOf(1);
-      expect(tree.children[0]).to.have.own.property('name').that.is.equal('App1');
-      expect(tree.children[0].children).to.have.lengthOf(1);
-      expect(tree.children[0].children[0]).to.have.own.property('name').that.is.equal('App2');
-      expect(tree.children[0].children[0].children).to.have.lengthOf(1);
-      expect(tree.children[0].children[0].children[0])
-        .to.have.own.property('name')
-        .that.is.equal('App1');
-      expect(tree.children[0].children[0].children[0].children).to.have.lengthOf(0);
+      expect(tree.get(0)).to.have.own.property('name').that.is.equal('App1');
+      expect(tree.get(0).children).to.have.lengthOf(1);
+      expect(tree.get(0, 0)).to.have.own.property('name').that.is.equal('App2');
+      expect(tree.get(0, 0).children).to.have.lengthOf(1);
+      expect(tree.get(0, 0, 0)).to.have.own.property('name').that.is.equal('App1');
+      expect(tree.get(0, 0, 0).children).to.have.lengthOf(0);
     });
   });
 
@@ -302,13 +296,13 @@ suite('Parser Test Suite', () => {
     test('Root should be named index, children should be named Head, Navbar, and Image, children of Navbar should be named Link and Image', () => {
       expect(tree).to.have.own.property('name').that.is.equal('index');
       expect(tree.children).to.have.lengthOf(3);
-      expect(tree.children[0]).to.have.own.property('name').that.is.equal('Head');
-      expect(tree.children[1]).to.have.own.property('name').that.is.equal('Navbar');
-      expect(tree.children[2]).to.have.own.property('name').that.is.equal('Image');
+      expect(tree.get(0)).to.have.own.property('name').that.is.equal('Head');
+      expect(tree.get(1)).to.have.own.property('name').that.is.equal('Navbar');
+      expect(tree.get(2)).to.have.own.property('name').that.is.equal('Image');
 
-      expect(tree.children[1].children).to.have.lengthOf(2);
-      expect(tree.children[1].children[0]).to.have.own.property('name').that.is.equal('Link');
-      expect(tree.children[1].children[1]).to.have.own.property('name').that.is.equal('Image');
+      expect(tree.get(1).children).to.have.lengthOf(2);
+      expect(tree.get(1, 0)).to.have.own.property('name').that.is.equal('Link');
+      expect(tree.get(1, 1)).to.have.own.property('name').that.is.equal('Image');
     });
   });
 
@@ -323,14 +317,14 @@ suite('Parser Test Suite', () => {
     test('Root should be named index, it should have one child named App', () => {
       expect(tree).to.have.own.property('name').that.is.equal('index');
       expect(tree.children).to.have.lengthOf(1);
-      expect(tree.children[0]).to.have.own.property('name').that.is.equal('App');
+      expect(tree.get(0)).to.have.own.property('name').that.is.equal('App');
     });
 
     test('App should have three children, Page1, Page2 and Page3, all found successfully', () => {
-      expect(tree.children[0].children[0]).to.have.own.property('name').that.is.equal('Page1');
-      expect(tree.children[0].children[0]).to.have.own.property('thirdParty').that.is.false;
-      expect(tree.children[0].children[1]).to.have.own.property('name').that.is.equal('Page2');
-      expect(tree.children[0].children[1]).to.have.own.property('thirdParty').that.is.false;
+      expect(tree.get(0, 0)).to.have.own.property('name').that.is.equal('Page1');
+      expect(tree.get(0, 0)).to.have.own.property('thirdParty').that.is.false;
+      expect(tree.get(0, 1)).to.have.own.property('name').that.is.equal('Page2');
+      expect(tree.get(0, 1)).to.have.own.property('thirdParty').that.is.false;
     });
   });
 
@@ -345,21 +339,21 @@ suite('Parser Test Suite', () => {
     test('Root should be named index, it should have one child named App', () => {
       expect(tree).to.have.own.property('name').that.is.equal('index');
       expect(tree.children).to.have.lengthOf(1);
-      expect(tree.children[0]).to.have.own.property('name').that.is.equal('App');
+      expect(tree.get(0)).to.have.own.property('name').that.is.equal('App');
     });
 
     test('Object destructured children PageA1, PageA2 successfully found. PageA1 is found with its filename, not as Alias.', () => {
-      expect(tree.children[0].children[0]).to.have.own.property('name').that.is.not.equal('Alias');
-      expect(tree.children[0].children[0]).to.have.own.property('name').that.is.equal('PageA1');
-      expect(tree.children[0].children[0]).to.have.own.property('thirdParty').that.is.false;
-      expect(tree.children[0].children[1]).to.have.own.property('name').that.is.equal('PageA2');
-      expect(tree.children[0].children[1]).to.have.own.property('thirdParty').that.is.false;
+      expect(tree.get(0, 0)).to.have.own.property('name').that.is.not.equal('Alias');
+      expect(tree.get(0, 0)).to.have.own.property('name').that.is.equal('PageA1');
+      expect(tree.get(0, 0)).to.have.own.property('thirdParty').that.is.false;
+      expect(tree.get(0, 1)).to.have.own.property('name').that.is.equal('PageA2');
+      expect(tree.get(0, 1)).to.have.own.property('thirdParty').that.is.false;
     });
     test('Array destructured require import PageB1, PageB2 all found successfully', () => {
-      expect(tree.children[0].children[2]).to.have.own.property('name').that.is.equal('PageB1');
-      expect(tree.children[0].children[2]).to.have.own.property('thirdParty').that.is.false;
-      expect(tree.children[0].children[3]).to.have.own.property('name').that.is.equal('PageB2');
-      expect(tree.children[0].children[3]).to.have.own.property('thirdParty').that.is.false;
+      expect(tree.get(0, 2)).to.have.own.property('name').that.is.equal('PageB1');
+      expect(tree.get(0, 2)).to.have.own.property('thirdParty').that.is.false;
+      expect(tree.get(0, 3)).to.have.own.property('name').that.is.equal('PageB2');
+      expect(tree.get(0, 3)).to.have.own.property('thirdParty').that.is.false;
     });
   });
 
@@ -374,21 +368,21 @@ suite('Parser Test Suite', () => {
     test('Root should be named index, it should have one child named App', () => {
       expect(tree).to.have.own.property('name').that.is.equal('index');
       expect(tree.children).to.have.lengthOf(1);
-      expect(tree.children[0]).to.have.own.property('name').that.is.equal('App');
+      expect(tree.get(0)).to.have.own.property('name').that.is.equal('App');
     });
 
     test('Object destructured children PageA1, PageA2 successfully found. PageA1 is found with its filename, not as Alias.', () => {
-      expect(tree.children[0].children[0]).to.have.own.property('name').that.is.not.equal('Alias');
-      expect(tree.children[0].children[0]).to.have.own.property('name').that.is.equal('PageA1');
-      expect(tree.children[0].children[0]).to.have.own.property('thirdParty').that.is.false;
-      expect(tree.children[0].children[1]).to.have.own.property('name').that.is.equal('PageA2');
-      expect(tree.children[0].children[1]).to.have.own.property('thirdParty').that.is.false;
+      expect(tree.get(0, 0)).to.have.own.property('name').that.is.not.equal('Alias');
+      expect(tree.get(0, 0)).to.have.own.property('name').that.is.equal('PageA1');
+      expect(tree.get(0, 0)).to.have.own.property('thirdParty').that.is.false;
+      expect(tree.get(0, 1)).to.have.own.property('name').that.is.equal('PageA2');
+      expect(tree.get(0, 1)).to.have.own.property('thirdParty').that.is.false;
     });
     test('Array destructured require import PageB1, PageB2 all found successfully', () => {
-      expect(tree.children[0].children[2]).to.have.own.property('name').that.is.equal('PageB1');
-      expect(tree.children[0].children[2]).to.have.own.property('thirdParty').that.is.false;
-      expect(tree.children[0].children[3]).to.have.own.property('name').that.is.equal('PageB2');
-      expect(tree.children[0].children[3]).to.have.own.property('thirdParty').that.is.false;
+      expect(tree.get(0, 2)).to.have.own.property('name').that.is.equal('PageB1');
+      expect(tree.get(0, 2)).to.have.own.property('thirdParty').that.is.false;
+      expect(tree.get(0, 3)).to.have.own.property('name').that.is.equal('PageB2');
+      expect(tree.get(0, 3)).to.have.own.property('thirdParty').that.is.false;
     });
   });
 });

--- a/sapling/src/test/suite/parser.test.ts
+++ b/sapling/src/test/suite/parser.test.ts
@@ -93,17 +93,17 @@ suite('Parser Test Suite', () => {
       expect(tree.children[2]).to.have.own.property('name').that.is.equal('Tippy');
     });
 
-    test('reactRouter should be designated as third party and reactRouter', () => {
-      expect(tree.children[0]).to.have.own.property('thirdParty').to.be.true;
-      expect(tree.children[1]).to.have.own.property('thirdParty').to.be.true;
+    test('isReactRouter should be designated as third party and isReactRouter', () => {
+      expect(tree.children[0]).to.have.own.property('isThirdParty').to.be.true;
+      expect(tree.children[1]).to.have.own.property('isThirdParty').to.be.true;
 
-      expect(tree.children[0]).to.have.own.property('reactRouter').to.be.true;
-      expect(tree.children[1]).to.have.own.property('reactRouter').to.be.true;
+      expect(tree.children[0]).to.have.own.property('isReactRouter').to.be.true;
+      expect(tree.children[1]).to.have.own.property('isReactRouter').to.be.true;
     });
 
-    test('Tippy should be designated as third party and not reactRouter', () => {
-      expect(tree.children[2]).to.have.own.property('thirdParty').to.be.true;
-      expect(tree.children[2]).to.have.own.property('reactRouter').to.be.false;
+    test('Tippy should be designated as third party and not isReactRouter', () => {
+      expect(tree.children[2]).to.have.own.property('isThirdParty').to.be.true;
+      expect(tree.children[2]).to.have.own.property('isReactRouter').to.be.false;
     });
   });
 
@@ -115,12 +115,12 @@ suite('Parser Test Suite', () => {
       tree = parser.parse();
     });
 
-    test('The reduxConnect properties of the connected component and the unconnected component should be true and false, respectively', () => {
+    test('The hasReduxConnect properties of the connected component and the unconnected component should be true and false, respectively', () => {
       expect(tree.children[1].children[0].name).to.equal('ConnectedContainer');
-      expect(tree.children[1].children[0]).to.have.own.property('reduxConnect').that.is.true;
+      expect(tree.children[1].children[0]).to.have.own.property('hasReduxConnect').that.is.true;
 
       expect(tree.children[1].children[1].name).to.equal('UnconnectedContainer');
-      expect(tree.children[1].children[1]).to.have.own.property('reduxConnect').that.is.false;
+      expect(tree.children[1].children[1]).to.have.own.property('hasReduxConnect').that.is.false;
     });
   });
 
@@ -328,9 +328,9 @@ suite('Parser Test Suite', () => {
 
     test('App should have three children, Page1, Page2 and Page3, all found successfully', () => {
       expect(tree.children[0].children[0]).to.have.own.property('name').that.is.equal('Page1');
-      expect(tree.children[0].children[0]).to.have.own.property('thirdParty').that.is.false;
+      expect(tree.children[0].children[0]).to.have.own.property('isThirdParty').that.is.false;
       expect(tree.children[0].children[1]).to.have.own.property('name').that.is.equal('Page2');
-      expect(tree.children[0].children[1]).to.have.own.property('thirdParty').that.is.false;
+      expect(tree.children[0].children[1]).to.have.own.property('isThirdParty').that.is.false;
     });
   });
 
@@ -351,15 +351,15 @@ suite('Parser Test Suite', () => {
     test('Object destructured children PageA1, PageA2 successfully found. PageA1 is found with its filename, not as Alias.', () => {
       expect(tree.children[0].children[0]).to.have.own.property('name').that.is.not.equal('Alias');
       expect(tree.children[0].children[0]).to.have.own.property('name').that.is.equal('PageA1');
-      expect(tree.children[0].children[0]).to.have.own.property('thirdParty').that.is.false;
+      expect(tree.children[0].children[0]).to.have.own.property('isThirdParty').that.is.false;
       expect(tree.children[0].children[1]).to.have.own.property('name').that.is.equal('PageA2');
-      expect(tree.children[0].children[1]).to.have.own.property('thirdParty').that.is.false;
+      expect(tree.children[0].children[1]).to.have.own.property('isThirdParty').that.is.false;
     });
     test('Array destructured require import PageB1, PageB2 all found successfully', () => {
       expect(tree.children[0].children[2]).to.have.own.property('name').that.is.equal('PageB1');
-      expect(tree.children[0].children[2]).to.have.own.property('thirdParty').that.is.false;
+      expect(tree.children[0].children[2]).to.have.own.property('isThirdParty').that.is.false;
       expect(tree.children[0].children[3]).to.have.own.property('name').that.is.equal('PageB2');
-      expect(tree.children[0].children[3]).to.have.own.property('thirdParty').that.is.false;
+      expect(tree.children[0].children[3]).to.have.own.property('isThirdParty').that.is.false;
     });
   });
 
@@ -380,15 +380,15 @@ suite('Parser Test Suite', () => {
     test('Object destructured children PageA1, PageA2 successfully found. PageA1 is found with its filename, not as Alias.', () => {
       expect(tree.children[0].children[0]).to.have.own.property('name').that.is.not.equal('Alias');
       expect(tree.children[0].children[0]).to.have.own.property('name').that.is.equal('PageA1');
-      expect(tree.children[0].children[0]).to.have.own.property('thirdParty').that.is.false;
+      expect(tree.children[0].children[0]).to.have.own.property('isThirdParty').that.is.false;
       expect(tree.children[0].children[1]).to.have.own.property('name').that.is.equal('PageA2');
-      expect(tree.children[0].children[1]).to.have.own.property('thirdParty').that.is.false;
+      expect(tree.children[0].children[1]).to.have.own.property('isThirdParty').that.is.false;
     });
-    test('Array destructured require import PageB1, PageB2 all found successfully', () => {
+    test('Array destructured children PageB1, PageB2 all found successfully', () => {
       expect(tree.children[0].children[2]).to.have.own.property('name').that.is.equal('PageB1');
-      expect(tree.children[0].children[2]).to.have.own.property('thirdParty').that.is.false;
+      expect(tree.children[0].children[2]).to.have.own.property('isThirdParty').that.is.false;
       expect(tree.children[0].children[3]).to.have.own.property('name').that.is.equal('PageB2');
-      expect(tree.children[0].children[3]).to.have.own.property('thirdParty').that.is.false;
+      expect(tree.children[0].children[3]).to.have.own.property('isThirdParty').that.is.false;
     });
   });
 });

--- a/sapling/src/test/suite/parser.test.ts
+++ b/sapling/src/test/suite/parser.test.ts
@@ -13,22 +13,21 @@ import { Tree } from '../../types';
 // import * as myExtension from '../../extension';
 
 suite('Parser Test Suite', () => {
-  let parser: SaplingParser, tree: Tree, file: string;
+  let tree: Tree, file: string;
 
   // UNPARSED TREE TEST
   describe('It initializes correctly', () => {
     before(() => {
       file = path.join(__dirname, '../../../src/test/test_apps/test_0/index.js');
-      parser = new SaplingParser(file);
+      tree = SaplingParser.parse(file);
     });
 
     test('A new instance of the parser class is an object', () => {
-      expect(parser).to.be.an('object');
+      expect(tree).to.be.an('object');
     });
 
-    test('It initializes with a proper entry file and an undefined tree', () => {
-      expect(parser.entryFile).to.equal(file);
-      expect(parser.tree).to.be.undefined;
+    test('It initializes with a proper entry file', () => {
+      expect(tree.filePath).to.equal(file);
     });
   });
 
@@ -36,8 +35,7 @@ suite('Parser Test Suite', () => {
   describe('It works for simple apps', () => {
     before(() => {
       file = path.join(__dirname, '../../../src/test/test_apps/test_0/index.js');
-      parser = new SaplingParser(file);
-      tree = parser.parse();
+      tree = SaplingParser.parse(file);
     });
 
     test('Parsing returns a object tree that is not undefined', () => {
@@ -55,8 +53,7 @@ suite('Parser Test Suite', () => {
   describe('It works for 2 components', () => {
     before(() => {
       file = path.join(__dirname, '../../../src/test/test_apps/test_1/index.js');
-      parser = new SaplingParser(file);
-      tree = parser.parse();
+      tree = SaplingParser.parse(file);
     });
 
     test('Parsed tree has a property called name with value index and one child with name App, which has its own child Main', () => {
@@ -82,8 +79,7 @@ suite('Parser Test Suite', () => {
   describe('It works for third party / React Router components and destructured imports', () => {
     before(() => {
       file = path.join(__dirname, '../../../src/test/test_apps/test_2/index.js');
-      parser = new SaplingParser(file);
-      tree = parser.parse();
+      tree = SaplingParser.parse(file);
     });
 
     test('Should parse destructured and third party imports', () => {
@@ -111,8 +107,7 @@ suite('Parser Test Suite', () => {
   describe('It identifies a Redux store connection and designates the component as such', () => {
     before(() => {
       file = path.join(__dirname, '../../../src/test/test_apps/test_3/index.js');
-      parser = new SaplingParser(file);
-      tree = parser.parse();
+      tree = SaplingParser.parse(file);
     });
 
     test('The hasReduxConnect properties of the connected component and the unconnected component should be true and false, respectively', () => {
@@ -128,8 +123,7 @@ suite('Parser Test Suite', () => {
   describe('It works for aliases', () => {
     before(() => {
       file = path.join(__dirname, '../../../src/test/test_apps/test_4/index.js');
-      parser = new SaplingParser(file);
-      tree = parser.parse();
+      tree = SaplingParser.parse(file);
     });
 
     test('alias should still give us components', () => {
@@ -147,8 +141,7 @@ suite('Parser Test Suite', () => {
     let names: string[], paths: string[], expectedNames: string[], expectedPaths: string[];
     before(() => {
       file = path.join(__dirname, '../../../src/test/test_apps/test_5/index.js');
-      parser = new SaplingParser(file);
-      tree = parser.parse();
+      tree = SaplingParser.parse(file);
 
       names = tree.children.map((child) => child.name);
       paths = tree.children.map((child) => child.filePath);
@@ -182,8 +175,7 @@ suite('Parser Test Suite', () => {
   describe('It works for badly imported children nodes', () => {
     before(() => {
       file = path.join(__dirname, '../../../src/test/test_apps/test_6/index.js');
-      parser = new SaplingParser(file);
-      tree = parser.parse();
+      tree = SaplingParser.parse(file);
     });
 
     test('improperly imported child component should exist but show an error', () => {
@@ -196,8 +188,7 @@ suite('Parser Test Suite', () => {
   describe('It should log an error when the parser encounters a javascript syntax error', () => {
     before(() => {
       file = path.join(__dirname, '../../../src/test/test_apps/test_7/index.js');
-      parser = new SaplingParser(file);
-      tree = parser.parse();
+      tree = SaplingParser.parse(file);
     });
 
     test('Should have a nonempty error message on the invalid child and not parse further', () => {
@@ -211,8 +202,7 @@ suite('Parser Test Suite', () => {
   describe('It should properly count repeat components and consolidate and grab their props', () => {
     before(() => {
       file = path.join(__dirname, '../../../src/test/test_apps/test_8/index.js');
-      parser = new SaplingParser(file);
-      tree = parser.parse();
+      tree = SaplingParser.parse(file);
     });
 
     test('Grandchild should have a count of 1', () => {
@@ -230,8 +220,7 @@ suite('Parser Test Suite', () => {
   describe('It should properly count repeat components and consolidate and grab their props', () => {
     before(() => {
       file = path.join(__dirname, '../../../src/test/test_apps/test_9/index.js');
-      parser = new SaplingParser(file);
-      tree = parser.parse();
+      tree = SaplingParser.parse(file);
     });
 
     test('Grandchild should have a count of 2', () => {
@@ -248,8 +237,7 @@ suite('Parser Test Suite', () => {
   describe('It should render children when children are rendered as values of prop called component', () => {
     before(() => {
       file = path.join(__dirname, '../../../src/test/test_apps/test_10/index.jsx');
-      parser = new SaplingParser(file);
-      tree = parser.parse();
+      tree = SaplingParser.parse(file);
     });
 
     test('Parent should have children that match the value stored in component prop', () => {
@@ -265,8 +253,7 @@ suite('Parser Test Suite', () => {
   describe('It should render the second call of mutually recursive components, but no further', () => {
     before(() => {
       file = path.join(__dirname, '../../../src/test/test_apps/test_11/index.js');
-      parser = new SaplingParser(file);
-      tree = parser.parse();
+      tree = SaplingParser.parse(file);
     });
 
     test('Tree should not be undefined', () => {
@@ -289,8 +276,7 @@ suite('Parser Test Suite', () => {
   describe('It should parse Next.js applications', () => {
     before(() => {
       file = path.join(__dirname, '../../../src/test/test_apps/test_12/pages/index.js');
-      parser = new SaplingParser(file);
-      tree = parser.parse();
+      tree = SaplingParser.parse(file);
     });
 
     test('Root should be named index, children should be named Head, Navbar, and Image, children of Navbar should be named Link and Image', () => {
@@ -310,8 +296,7 @@ suite('Parser Test Suite', () => {
   describe('It should parse VariableDeclaration imports including React.lazy imports', () => {
     before(() => {
       file = path.join(__dirname, '../../../src/test/test_apps/test_13/index.js');
-      parser = new SaplingParser(file);
-      tree = parser.parse();
+      tree = SaplingParser.parse(file);
     });
 
     test('Root should be named index, it should have one child named App', () => {
@@ -332,8 +317,7 @@ suite('Parser Test Suite', () => {
   describe('It should parse require function calls with destructuring and aliasing', () => {
     before(() => {
       file = path.join(__dirname, '../../../src/test/test_apps/test_14/index.js');
-      parser = new SaplingParser(file);
-      tree = parser.parse();
+      tree = SaplingParser.parse(file);
     });
 
     test('Root should be named index, it should have one child named App', () => {
@@ -361,8 +345,7 @@ suite('Parser Test Suite', () => {
   describe('It should parse variable declaration imports with Array Destructuring, and Object Destructuring with Aliasing', () => {
     before(() => {
       file = path.join(__dirname, '../../../src/test/test_apps/test_15/index.js');
-      parser = new SaplingParser(file);
-      tree = parser.parse();
+      tree = SaplingParser.parse(file);
     });
 
     test('Root should be named index, it should have one child named App', () => {

--- a/sapling/src/test/suite/parser.test.ts
+++ b/sapling/src/test/suite/parser.test.ts
@@ -1,8 +1,10 @@
-import { SaplingParser } from '../../SaplingParser';
-import { Tree } from '../../types/Tree';
-import { describe, suite , test, before} from 'mocha';
-import { expect } from 'chai';
 import * as path from 'path';
+import * as assert from 'assert';
+import { describe, suite, test, before } from 'mocha';
+import { expect } from 'chai';
+
+import { SaplingParser } from '../../SaplingParser';
+import { Tree } from '../../types';
 
 // You can import and use all API from the 'vscode' module
 // as well as import your extension to test it

--- a/sapling/src/test/suite/parser.test.ts
+++ b/sapling/src/test/suite/parser.test.ts
@@ -12,11 +12,11 @@ import { Tree } from '../../types';
 // import * as myExtension from '../../extension';
 
 suite('Parser Test Suite', () => {
-  let parser : SaplingParser, tree : Tree, file : string;
+  let parser: SaplingParser, tree: Tree, file: string;
 
   // UNPARSED TREE TEST
   describe('It initializes correctly', () => {
-    before( () => {
+    before(() => {
       file = path.join(__dirname, '../../../src/test/test_apps/test_0/index.js');
       parser = new SaplingParser(file);
     });
@@ -33,7 +33,7 @@ suite('Parser Test Suite', () => {
 
   // TEST 0: ONE CHILD
   describe('It works for simple apps', () => {
-    before( () => {
+    before(() => {
       file = path.join(__dirname, '../../../src/test/test_apps/test_0/index.js');
       parser = new SaplingParser(file);
       tree = parser.parse();
@@ -90,7 +90,6 @@ suite('Parser Test Suite', () => {
       expect(tree.children[0]).to.have.own.property('name').that.is.oneOf(['Switch', 'Route']);
       expect(tree.children[1]).to.have.own.property('name').that.is.oneOf(['Switch', 'Route']);
       expect(tree.children[2]).to.have.own.property('name').that.is.equal('Tippy');
-
     });
 
     test('reactRouter should be designated as third party and reactRouter', () => {
@@ -144,22 +143,22 @@ suite('Parser Test Suite', () => {
 
   // TEST 5: MISSING EXTENSIONS AND UNUSED IMPORTS
   describe('It works for extension-less imports', () => {
-    let names: string[], paths: string [], expectedNames : string[], expectedPaths : string[];
+    let names: string[], paths: string[], expectedNames: string[], expectedPaths: string[];
     before(() => {
       file = path.join(__dirname, '../../../src/test/test_apps/test_5/index.js');
       parser = new SaplingParser(file);
       tree = parser.parse();
 
-      names = tree.children.map(child => child.name);
-      paths = tree.children.map(child => child.filePath);
+      names = tree.children.map((child) => child.name);
+      paths = tree.children.map((child) => child.filePath);
 
       expectedNames = ['JS', 'JSX', 'TS', 'TSX'];
       expectedPaths = [
         '../../../src/test/test_apps/test_5/components/JS.js',
         '../../../src/test/test_apps/test_5/components/JSX.jsx',
         '../../../src/test/test_apps/test_5/components/TS.ts',
-        '../../../src/test/test_apps/test_5/components/TSX.tsx'
-      ].map( el => path.resolve(__dirname, el));
+        '../../../src/test/test_apps/test_5/components/TSX.tsx',
+      ].map((el) => path.resolve(__dirname, el));
     });
 
     test('Check children match expected children', () => {
@@ -256,8 +255,12 @@ suite('Parser Test Suite', () => {
       expect(tree.children[0]).to.have.own.property('name').that.is.equal('BrowserRouter');
       expect(tree.children[1]).to.have.own.property('name').that.is.equal('App');
 
-      expect(tree.children[1].children[3]).to.have.own.property('name').that.is.equal('DrillCreator');
-      expect(tree.children[1].children[4]).to.have.own.property('name').that.is.equal('HistoryDisplay');
+      expect(tree.children[1].children[3])
+        .to.have.own.property('name')
+        .that.is.equal('DrillCreator');
+      expect(tree.children[1].children[4])
+        .to.have.own.property('name')
+        .that.is.equal('HistoryDisplay');
     });
   });
 
@@ -280,7 +283,9 @@ suite('Parser Test Suite', () => {
       expect(tree.children[0].children).to.have.lengthOf(1);
       expect(tree.children[0].children[0]).to.have.own.property('name').that.is.equal('App2');
       expect(tree.children[0].children[0].children).to.have.lengthOf(1);
-      expect(tree.children[0].children[0].children[0]).to.have.own.property('name').that.is.equal('App1');
+      expect(tree.children[0].children[0].children[0])
+        .to.have.own.property('name')
+        .that.is.equal('App1');
       expect(tree.children[0].children[0].children[0].children).to.have.lengthOf(0);
     });
   });

--- a/sapling/src/test/test_apps/test_14/components/App.jsx
+++ b/sapling/src/test/test_apps/test_14/components/App.jsx
@@ -1,0 +1,13 @@
+const { PageA1: Alias, PageA2 } = require('./PageA');
+const [PageB1, PageB2] = require('./PageB');
+
+export default function Routes() {
+  return (
+    <div>
+      <Alias />
+      <PageA2 />
+      <PageB1 />
+      <PageB2 />
+    </div>
+  );
+}

--- a/sapling/src/test/test_apps/test_14/components/PageA.jsx
+++ b/sapling/src/test/test_apps/test_14/components/PageA.jsx
@@ -1,0 +1,19 @@
+import React, { Component } from 'react';
+
+function PageA1() {
+  return (
+    <section>
+      <div>This is Page A1</div>
+    </section>
+  );
+}
+
+function PageA2() {
+  return (
+    <section>
+      <div>This is Page A2</div>
+    </section>
+  );
+}
+
+module.exports = { PageA1, PageA2 };

--- a/sapling/src/test/test_apps/test_14/components/PageB.jsx
+++ b/sapling/src/test/test_apps/test_14/components/PageB.jsx
@@ -1,0 +1,23 @@
+import React, { Component } from 'react';
+
+class PageB1 extends Component {
+  render() {
+    return (
+      <section>
+        <div>I am PageB1.</div>
+      </section>
+    );
+  }
+}
+
+class PageB2 extends Component {
+  render() {
+    return (
+      <section>
+        <div>I am PageB2.</div>
+      </section>
+    );
+  }
+}
+
+module.exports = [PageB1, PageB2];

--- a/sapling/src/test/test_apps/test_14/index.js
+++ b/sapling/src/test/test_apps/test_14/index.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { render } from 'react-dom';
+
+import App from './components/App.jsx';
+
+// TEST 15 - Tests following:
+// require statements
+// 1) Array Destructuring
+// const [foo, bar] = require('module');
+// 2) Object Destructuring + Aliasing
+// const { foo: bar } = require('module');
+
+render(
+  <div>
+    <App />
+  </div>,
+  document.getElementById('root')
+);

--- a/sapling/src/test/test_apps/test_15/components/App.jsx
+++ b/sapling/src/test/test_apps/test_15/components/App.jsx
@@ -1,0 +1,13 @@
+const { PageA1: Alias, PageA2 } = import('./PageA');
+const [PageB1, PageB2] = import('./PageB');
+
+export default function Routes() {
+  return (
+    <div>
+      <Alias />
+      <PageA2 />
+      <PageB1 />
+      <PageB2 />
+    </div>
+  );
+}

--- a/sapling/src/test/test_apps/test_15/components/PageA.jsx
+++ b/sapling/src/test/test_apps/test_15/components/PageA.jsx
@@ -1,0 +1,19 @@
+import React, { Component } from 'react';
+
+function PageA1() {
+  return (
+    <section>
+      <div>This is Page A1</div>
+    </section>
+  );
+}
+
+function PageA2() {
+  return (
+    <section>
+      <div>This is Page A2</div>
+    </section>
+  );
+}
+
+module.exports = { PageA1, PageA2 };

--- a/sapling/src/test/test_apps/test_15/components/PageB.jsx
+++ b/sapling/src/test/test_apps/test_15/components/PageB.jsx
@@ -1,0 +1,23 @@
+import React, { Component } from 'react';
+
+class PageB1 extends Component {
+  render() {
+    return (
+      <section>
+        <div>I am PageB1.</div>
+      </section>
+    );
+  }
+}
+
+class PageB2 extends Component {
+  render() {
+    return (
+      <section>
+        <div>I am PageB2.</div>
+      </section>
+    );
+  }
+}
+
+module.exports = [PageB1, PageB2];

--- a/sapling/src/test/test_apps/test_15/index.js
+++ b/sapling/src/test/test_apps/test_15/index.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { render } from 'react-dom';
+
+import App from './components/App.jsx';
+
+// TEST 15 - Tests following:
+// Variable declaration import statements
+// 1) Array Destructuring
+// const [foo, bar] = import('module');
+// 2) Object Destructuring + Aliasing
+// const { foo: bar } = import('module');
+
+render(
+  <div>
+    <App />
+  </div>,
+  document.getElementById('root')
+);

--- a/sapling/src/types/ImportData.ts
+++ b/sapling/src/types/ImportData.ts
@@ -1,0 +1,5 @@
+export type ImportData = {
+  importPath: string;
+  importName: string;
+  importAlias?: string;
+};

--- a/sapling/src/types/ImportObj.ts
+++ b/sapling/src/types/ImportObj.ts
@@ -1,5 +1,0 @@
-// ImportObj type, used by SaplingParser
-// ImportObj holds data about imports in the current JS/TS file
-export type ImportObj = {
-  [key : string]: {importPath: string, importName: string}
-};

--- a/sapling/src/types/Token.ts
+++ b/sapling/src/types/Token.ts
@@ -1,0 +1,25 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { SourceLocation } from '@babel/types';
+
+// based on deprecated babylon parser TokenType
+// and up-to-date BaseNode interface in @babel/types
+export interface Token {
+  [key: string]: Token[keyof Token];
+  type: Partial<{
+    label: string;
+    keyword: 'let' | 'const' | 'var' | 'function' | string | undefined;
+    beforeExpr: boolean;
+    startsExpr: boolean;
+    rightAssociative: boolean;
+    isLoop: boolean;
+    isAssign: boolean;
+    prefix: boolean;
+    postfix: boolean;
+    binop: null | any;
+    updateContext: null | any;
+  }>;
+  value: string | number;
+  start: number | null;
+  end: number | null;
+  loc: SourceLocation | null;
+}

--- a/sapling/src/types/Tree.ts
+++ b/sapling/src/types/Tree.ts
@@ -9,9 +9,9 @@ export interface SerializedTree {
   readonly fileName: string;
   readonly filePath: string;
   readonly importPath: string;
-  readonly isExpanded: boolean;
   readonly depth: number;
   readonly count: number;
+  readonly isExpanded: boolean;
   readonly isThirdParty: boolean;
   readonly isReactRouter: boolean;
   readonly hasReduxConnect: boolean;
@@ -25,43 +25,132 @@ export interface SerializedTree {
 export class Tree {
   [key: string]: unknown;
   readonly type = 'Tree';
-  readonly id: string;
-  readonly name: string;
-  readonly fileName: string;
-  readonly filePath: string;
-  readonly importPath: string;
-  isExpanded: boolean;
-  depth: number;
-  count: number;
-  isThirdParty: boolean;
-  isReactRouter: boolean;
-  hasReduxConnect: boolean;
-  readonly children: Array<Tree>;
-  readonly parentId: string | null | undefined;
-  readonly parentList: string[];
-  props: Record<string, boolean>;
-  error: '' | 'File not found.' | 'Error while processing this file/node.';
+  private readonly _id: string;
+  private readonly _name: string;
+  private readonly _fileName: string;
+  private readonly _filePath: string;
+  private readonly _importPath: string;
+  private _depth: number;
+  private _count: number;
+  private _isExpanded: boolean;
+  private _isThirdParty: boolean;
+  private _isReactRouter: boolean;
+  private _hasReduxConnect: boolean;
+  private readonly _children: Array<Tree>;
+  private readonly _parentId: string | null | undefined;
+  private readonly _parentList: string[];
+  private readonly _props: Record<string, boolean>;
+  private _error: '' | 'File not found.' | 'Error while processing this file/node.';
 
   constructor(node?: Partial<Tree>) {
-    this.id = getNonce(); // shallow copies made from constructor do not share identifiers
-    this.name = node?.name || '';
-    this.fileName = node?.fileName || '';
-    this.filePath = node?.filePath || '';
-    this.importPath = node?.importPath || '';
-    this.isExpanded = node?.isExpanded || false;
-    this.depth = node?.depth || 0;
-    this.count = node?.count || 1;
-    this.isThirdParty = node?.isThirdParty || false;
-    this.isReactRouter = node?.isReactRouter || false;
-    this.hasReduxConnect = node?.hasReduxConnect || false;
-    this.children = node?.children || [];
-    this.parentId = node?.parentId;
-    this.parentList = node?.parentList || [];
-    this.props = node?.props || {};
-    this.error = node?.error || '';
+    this._id = getNonce(); // shallow copies made from constructor do not share identifiers
+    this._name = node?.name || '';
+    this._fileName = node?.fileName || '';
+    this._filePath = node?.filePath || '';
+    this._importPath = node?.importPath || '';
+    this._depth = node?.depth || 0;
+    this._count = node?.count || 1;
+    this._isExpanded = node?.isExpanded || false;
+    this._isThirdParty = node?.isThirdParty || false;
+    this._isReactRouter = node?.isReactRouter || false;
+    this._hasReduxConnect = node?.hasReduxConnect || false;
+    this._children = node?.children || [];
+    this._parentId = node?.parentId;
+    this._parentList = node?.parentList || [];
+    this._props = node?.props || {};
+    this._error = node?.error || '';
   }
 
-  /** Getter for descendant nodes in the subtree of 'this'.
+  /** All class fields are accessible using member expressions.
+   * To prevent read access to a field, remove its getter method. */
+
+  public get id(): string {
+    return this._id;
+  }
+  public get name(): string {
+    return this._name;
+  }
+  public get fileName(): string {
+    return this._fileName;
+  }
+  public get filePath(): string {
+    return this._filePath;
+  }
+  public get importPath(): string {
+    return this._importPath;
+  }
+  public get depth(): number {
+    return this._depth;
+  }
+  public get count(): number {
+    return this._count;
+  }
+  public get isExpanded(): boolean {
+    return this._isExpanded;
+  }
+  public get isThirdParty(): boolean {
+    return this._isThirdParty;
+  }
+  public get isReactRouter(): boolean {
+    return this._isReactRouter;
+  }
+  public get hasReduxConnect(): boolean {
+    return this._hasReduxConnect;
+  }
+  public get children(): Array<Tree> {
+    return this._children;
+  }
+  public get parentId(): string | null | undefined {
+    return this._parentId;
+  }
+  public get parentList(): string[] {
+    return this._parentList;
+  }
+  public get props(): Record<string, boolean> {
+    return this._props;
+  }
+  public get error(): '' | 'File not found.' | 'Error while processing this file/node.' {
+    return this._error;
+  }
+
+  /** Sets or modifies value of class fields and performs input validation.
+   * Direct assignment of class fields using member expressions is not allowed.
+   * @param key The class field to be modified.
+   * @param value The value to be assigned.
+   * Defines unalterable class fields: 'id', 'name', ' fileName', 'filePath', 'importPath', 'parentId', 'parentList'.
+   * Use for complete replacement of 'children', 'props' elements (for mutation, use array/object methods).
+   */
+  public set(key: keyof Tree, value: Tree[keyof Tree]): void {
+    if (key === 'children') {
+      if (value && Array.isArray(value) && (!value.length || value[0] instanceof Tree)) {
+        this._children.splice(0, this._children.length);
+        this._children.push(...(value as Array<Tree>));
+        return;
+      }
+      throw new Error('Invalid input children array.');
+    }
+    if (key === 'props') {
+      if (
+        value &&
+        typeof value === 'object' &&
+        Object.entries(value).every(([k, v]) => typeof k === 'string' && typeof v === 'boolean')
+      ) {
+        Object.keys(this._props).forEach((k) => delete this._props[k]);
+        Object.entries(value).forEach(([k, v]: [string, boolean]) => (this._props[k] = v));
+        return;
+      }
+      throw new Error('Invalid input props object.');
+    }
+    if (
+      ['id', 'name', ' fileName', 'filePath', 'importPath', 'parentId', 'parentList'].includes(
+        key as string
+      )
+    ) {
+      throw new Error(`Cannot alter readonly property: ${key}. Create new tree instead.`);
+    } else this[`_${key}`] = value;
+  }
+
+  /** Finds tree node(s) and returns reference pointer.
    * @param id
    * @returns Tree node with matching id, or undefined if not found.
    * @param filePath
@@ -73,7 +162,7 @@ export class Tree {
    * e.g. (0) is the first child of root
    * e.g. (0, 2, 1) would be the second child of the third child of the first child of root
    * i.e. this.children[0].children[2].children[1]
-   * @returns the Tree node found at the destination of this traversal path
+   * @returns Tree node found at the destination of input traversal path.
    */
   public get(...path: number[]): Tree;
   public get(...input: Array<unknown>): unknown {
@@ -85,8 +174,7 @@ export class Tree {
       (typeof input[0] !== 'string' && typeof input[0] !== 'number')
     ) {
       throw new Error('Invalid input type.');
-    }
-    if (typeof input[0] === 'string') {
+    } else if (typeof input[0] === 'string') {
       const { subtree } = this;
       const getById: Tree | undefined = subtree.filter(({ id }) => input[0] === id).pop();
       const getByFilePath: Array<Tree> = subtree.filter(({ filePath }) => input[0] === filePath);
@@ -106,24 +194,6 @@ export class Tree {
     }, this) as Tree;
   }
 
-  /** Modifies value of class fields.
-   * Prohibits mutation of readonly properties: 'id', 'name', ' fileName', 'filePath', 'importPath', 'parentId', 'parentList'.
-   */
-  public set(key: keyof Tree, value: Tree[keyof Tree]): void {
-    if (key === 'children') {
-      if (value && Array.isArray(value) && (!value.length || value[0] instanceof Tree)) {
-        this[key].splice(0, this.children.length);
-        this[key].push(...(value as Array<Tree>));
-      } else throw new Error('Invalid children array.');
-    } else if (
-      ['id', 'name', ' fileName', 'filePath', 'importPath', 'parentId', 'parentList'].includes(
-        key as string
-      )
-    ) {
-      throw new Error(`Cannot alter readonly property: ${key}. Create new tree instead.`);
-    } else this[key] = value;
-  }
-
   public isEmpty(): boolean {
     return !this.name.length || this.parentId === undefined;
   }
@@ -141,11 +211,17 @@ export class Tree {
    * @returns JSON-stringifyable SerializedTree object
    */
   public serialize(): SerializedTree {
-    const recurse = (node: Tree): SerializedTree => ({
-      ...node,
-      type: 'SerializedTree',
-      children: node.children.map((child) => recurse(child)),
-    });
+    const recurse = (node: Tree): SerializedTree => {
+      const obj = {
+        ...node,
+        _type: 'SerializedTree',
+        _children: node.children.map((child) => recurse(child)),
+      };
+      return Object.entries(obj).reduce((acc, [k, v]) => {
+        acc[k.slice(1)] = v;
+        return acc;
+      }, {} as SerializedTree);
+    };
     return recurse(this);
   }
 

--- a/sapling/src/types/Tree.ts
+++ b/sapling/src/types/Tree.ts
@@ -82,6 +82,26 @@ export class Tree {
     }, this) as Tree;
   }
 
+  /** Modifies value of public class fields.
+   * Prohibits mutation of readonly properties: 'id', 'name', ' fileName', 'filePath', 'importPath', 'parentId', 'parentList'.
+   */
+  public set(key: keyof Tree, value: Tree[keyof Tree]): void {
+    if (key === 'children') {
+      if (value && Array.isArray(value) && (!value.length || value[0] instanceof Tree)) {
+        this[key].splice(0, this.children.length);
+        this[key].push(...(value as Array<Tree>));
+      } else throw new Error('Invalid children array.');
+    } else if (
+      ['id', 'name', ' fileName', 'filePath', 'importPath', 'parentId', 'parentList'].includes(
+        key as string
+      )
+    ) {
+      throw new Error('Cannot alter readonly property: ' + key + '. Create new tree instead.');
+    }
+    // @ts-expect-error
+    else this[key] = value;
+  }
+
   public isEmpty(): boolean {
     return !this.name.length || this.parentId === undefined;
   }

--- a/sapling/src/types/Tree.ts
+++ b/sapling/src/types/Tree.ts
@@ -115,25 +115,26 @@ export class Tree {
     return !this.isThirdParty && !this.isReactRouter;
   }
 
-  /** Switches isExpanded property state.
-   * @param expandedState if not undefined, defines value of isExpanded property for this node.
-   * If expandedState is undefined, isExpanded property is negated.
-   */
-  private toggleExpanded(expandedState?: boolean): void {
-    if (expandedState === undefined) this.set('isExpanded', !this.isExpanded);
-    else this.set('isExpanded', expandedState);
+  /** Switches isExpanded property state. */
+  private toggleExpanded(): void {
+    this.set('isExpanded', !this.isExpanded);
   }
 
+  /** Finds subtree node and changes isExpanded property state.
+   * @param expandedState if not undefined, defines value of isExpanded property for target node.
+   * If expandedState is undefined, isExpanded property is negated.
+   */
   public findAndToggleExpanded(id: string, expandedState?: boolean): void {
     const target = this.get(id) as Tree | undefined;
     if (target === undefined) throw new Error('Invalid input id.');
-    target.toggleExpanded(expandedState);
+    if (expandedState === undefined) target.toggleExpanded();
+    else target.set('isExpanded', expandedState);
   }
 
   /** Triggers on file save event.
    * Finds node(s) that match saved document's file path,
    * reparses their subtrees to reflect updated document content,
-   * and restores previous expanded state for descendants.
+   * and restores previous isExpanded state for descendants.
    */
   public updateOnSave(savedFilePath: string): void {
     const targetNodes = this.get(savedFilePath) as Array<Tree>;
@@ -150,7 +151,8 @@ export class Tree {
       SaplingParser.parse(target);
 
       const restoreExpanded = (node: Tree): void => {
-        node.toggleExpanded(
+        node.set(
+          'isExpanded',
           prevState.some(
             ({ depth, filePath, isExpanded }) =>
               isExpanded && node.depth === depth && node.filePath === filePath

--- a/sapling/src/types/Tree.ts
+++ b/sapling/src/types/Tree.ts
@@ -1,20 +1,129 @@
-// Tree type used by SaplingParser
+import { getNonce } from '../helpers/getNonce';
 
+// Tree type used by SaplingParser
 // The component tree is a nested data structure, where children are Trees
-export type Tree = {
-  id: string;
-  name: string;
-  fileName: string;
-  filePath: string;
-  importPath: string;
+export class Tree {
+  readonly id: string;
+  readonly name: string;
+  readonly fileName: string;
+  readonly filePath: string;
+  readonly importPath: string;
   expanded: boolean;
   depth: number;
   count: number;
   thirdParty: boolean;
   reactRouter: boolean;
   reduxConnect: boolean;
-  children: Array<Tree>;
-  parentList: string[];
-  props: Record<string, boolean>;
-  error: string;
-};
+  readonly children: Array<Tree>;
+  readonly parentId: string | null | undefined;
+  readonly parentList: string[];
+  readonly props: Record<string, boolean>;
+  error: '' | 'File not found.' | 'Error while processing this file/node';
+
+  constructor(node?: Partial<Tree>) {
+    this.id = getNonce(); // shallow copies do not share identifiers
+    this.name = node?.name || '';
+    this.fileName = node?.fileName || '';
+    this.filePath = node?.filePath || '';
+    this.importPath = node?.importPath || '';
+    this.expanded = node?.expanded || false;
+    this.depth = node?.depth || 0;
+    this.count = node?.count || 1;
+    this.thirdParty = node?.thirdParty || false;
+    this.reactRouter = node?.reactRouter || false;
+    this.reduxConnect = node?.reduxConnect || false;
+    this.children = node?.children || [];
+    this.parentId = node?.parentId;
+    this.parentList = node?.parentList || [];
+    this.props = node?.props || {};
+    this.error = node?.error || '';
+  }
+
+  /** Getter for descendant nodes in the subtree of 'this'.
+   * @param id
+   * @returns Tree node with matching id, or undefined if not found.
+   * @param filePath
+   * @returns Array of matching Tree nodes, or empty array if none are found.
+   */
+  public get(...input: string[]): Tree | Array<Tree> | undefined;
+  /** Get by following traversal path from root to target node
+   * @param path: path expressed by sequence of each intermediate vertex's index in its parent's children array property.
+   * e.g. (0) is the first child of root
+   * e.g. (0, 2, 1) would be the second child of the third child of the first child of root
+   * i.e. this.children[0].children[2].children[1]
+   * @returns the Tree node found at the destination of this traversal path
+   */
+  public get(...path: number[]): Tree;
+  public get(...input: Array<unknown>): unknown {
+    if (
+      !input ||
+      !Array.isArray(input) ||
+      !input.length ||
+      (typeof input[0] === 'string' && input.length > 1) ||
+      (typeof input[0] !== 'string' && typeof input[0] !== 'number')
+    ) {
+      throw new Error('Invalid input type.');
+    }
+    if (typeof input[0] === 'string') {
+      const getById: Tree | undefined = this.subTree.filter(({ id }) => input[0] === id).pop();
+      const getByFilePath: Array<Tree> = this.subTree.filter(
+        ({ filePath }) => input[0] === filePath
+      );
+      return getById === undefined && !getByFilePath.length ? undefined : getById || getByFilePath;
+    }
+    return input.reduce((acc: Tree, curr: number, i) => {
+      if (!acc || !acc.children[curr]) {
+        throw new Error(`Invalid entry at index ${i} of input path array.`);
+      }
+      if (curr < 0 || curr >= acc.children.length) {
+        throw new Error(`Entry out of bounds at index ${i} of input path array.`);
+      }
+      return acc.children[curr];
+    }, this) as Tree;
+  }
+
+  public isEmpty(): boolean {
+    return !this.name.length || this.parentId === undefined;
+  }
+
+  public isRoot(): boolean {
+    return !this.isEmpty() && this.parentId === null;
+  }
+
+  public isFile(): boolean {
+    return !this.thirdParty && !this.reactRouter;
+  }
+
+  /** Switches expanded property state.
+   * @param expandedState if not undefined, defines value of expanded property for this node.
+   * If expandedState is undefined, expanded property is negated.
+   */
+  public toggleExpanded(expandedState?: boolean): void {
+    this.expanded = expandedState === undefined ? !this.expanded : expandedState;
+  }
+
+  public findAndToggleExpanded(id: string, expandedState?: boolean): void {
+    const target = this.get(id) as Tree | undefined;
+    if (target === undefined) throw new Error('Invalid input id.');
+    target.toggleExpanded(expandedState);
+  }
+
+  /** @returns Normalized array containing all descendants in subtree of 'this' except for the root node. */
+  private get subTree(): Array<Tree> {
+    const descendants: Array<Tree> = [];
+    const callback = (node: Tree) => {
+      descendants.push(...node.children);
+    };
+    this.traverse(callback);
+    return descendants;
+  }
+
+  // Traverses all nodes of current component tree and applies callback to each node
+  private traverse(callback: (node: Tree) => void): void {
+    callback(this);
+    if (!this.children || !this.children.length) return;
+    this.children.forEach((child) => {
+      child.traverse(callback);
+    });
+  }
+}

--- a/sapling/src/types/Tree.ts
+++ b/sapling/src/types/Tree.ts
@@ -7,12 +7,12 @@ export type Tree = {
   fileName: string;
   filePath: string;
   importPath: string;
-  expanded: boolean;
+  isExpanded: boolean;
   depth: number;
   count: number;
-  thirdParty: boolean;
-  reactRouter: boolean;
-  reduxConnect: boolean;
+  isThirdParty: boolean;
+  isReactRouter: boolean;
+  hasReduxConnect: boolean;
   children: Array<Tree>;
   parentList: string[];
   props: Record<string, boolean>;

--- a/sapling/src/types/Tree.ts
+++ b/sapling/src/types/Tree.ts
@@ -13,8 +13,8 @@ export type Tree = {
   thirdParty: boolean;
   reactRouter: boolean;
   reduxConnect: boolean;
-  children: Tree[];
+  children: Array<Tree>;
   parentList: string[];
-  props: { [key: string]: boolean; };
+  props: Record<string, boolean>;
   error: string;
 };

--- a/sapling/src/types/index.ts
+++ b/sapling/src/types/index.ts
@@ -1,0 +1,3 @@
+export * from './ImportData';
+export * from './Token';
+export * from './Tree';

--- a/sapling/src/webviews/components/Navbar.tsx
+++ b/sapling/src/webviews/components/Navbar.tsx
@@ -5,23 +5,22 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faDownload } from '@fortawesome/free-solid-svg-icons';
 
 const Navbar = ({ rootFile }: any) => {
-  
   const fileMessage = () => {
     // tell the extension that the user wants to open a file
     tsvscode.postMessage({
-        type: "onFile",
-        value: null
+      type: 'onFile',
+      value: null,
     });
   };
 
   // Render section
   return (
     <div className="navbar">
-      <button id="file" className="inputFile" onClick={() => fileMessage()}>
-      <label htmlFor="file">
-        <FontAwesomeIcon icon={faDownload} />
-        <strong id="strong_file">{rootFile ? ` ${rootFile}` : ' Choose a file...'}</strong>
-      </label>
+      <button type="submit" id="file" className="inputFile" onClick={fileMessage}>
+        <label htmlFor="file">
+          <FontAwesomeIcon icon={faDownload} />
+          <strong id="strong_file">{rootFile ? ` ${rootFile}` : ' Choose a file...'}</strong>
+        </label>
       </button>
     </div>
   );

--- a/sapling/src/webviews/components/Navbar.tsx
+++ b/sapling/src/webviews/components/Navbar.tsx
@@ -1,6 +1,4 @@
 import * as React from 'react';
-import { useState, useEffect } from 'react';
-import * as ReactDOM from 'react-dom';
 
 // imports for the icons
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -14,8 +12,8 @@ const Navbar = ({ rootFile }: any) => {
     e.target.value = null;
     if (filePath) {
       tsvscode.postMessage({
-        type: "onFile",
-        value: filePath
+        type: 'onFile',
+        value: filePath,
       });
     }
   };
@@ -23,9 +21,17 @@ const Navbar = ({ rootFile }: any) => {
   // Render section
   return (
     <div className="navbar">
-      <input type="file" name="file" id="file" className="inputfile" onChange={(e) => {fileMessage(e);}}/>
+      <input
+        type="file"
+        name="file"
+        id="file"
+        className="inputfile"
+        onChange={(e) => {
+          fileMessage(e);
+        }}
+      />
       <label htmlFor="file">
-        <FontAwesomeIcon icon={faDownload}/>
+        <FontAwesomeIcon icon={faDownload} />
         <strong id="strong_file">{rootFile ? ` ${rootFile}` : ' Choose a file...'}</strong>
       </label>
     </div>

--- a/sapling/src/webviews/components/Sidebar.tsx
+++ b/sapling/src/webviews/components/Sidebar.tsx
@@ -10,7 +10,7 @@ const Sidebar = () => {
   // state variables for the incomimg treeData, parsed viewData, user's settings, and the root file name
   const [treeData, setTreeData]: any = useState();
   const [viewData, setViewData]: any = useState();
-  const [settings, setSettings]: [{[key : string]: boolean} | undefined, Function] = useState();
+  const [settings, setSettings]: [{ [key: string]: boolean } | undefined, Function] = useState();
   const [rootFile, setRootFile]: [string | undefined, Function] = useState();
 
   // useEffect whenever the Sidebar is rendered
@@ -20,13 +20,13 @@ const Sidebar = () => {
       const message = event.data;
       switch (message.type) {
         // Listener to receive the tree data, update navbar and tree view
-        case("parsed-data"): {
+        case 'parsed-data': {
           setRootFile(message.value.fileName);
           setTreeData([message.value]);
           break;
         }
         // Listener to receive the user's settings
-        case("settings-data"): {
+        case 'settings-data': {
           setSettings(message.value);
           break;
         }
@@ -35,14 +35,14 @@ const Sidebar = () => {
 
     // Post message to the extension whenever sapling is opened
     tsvscode.postMessage({
-      type: "onSaplingVisible",
-      value: null
+      type: 'onSaplingVisible',
+      value: null,
     });
 
     // Post message to the extension for the user's settings whenever sapling is opened
     tsvscode.postMessage({
-      type: "onSettingsAcquire",
-      value: null
+      type: 'onSettingsAcquire',
+      value: null,
     });
   }, []);
 
@@ -55,12 +55,12 @@ const Sidebar = () => {
   }, [treeData, settings]);
 
   // Edits and returns component tree based on users settings
-  const parseViewTree = () : void => {
+  const parseViewTree = (): void => {
     // Deep copy of the treeData passed in
     const treeParsed = JSON.parse(JSON.stringify(treeData[0]));
 
     // Helper function for the recursive parsing
-    const traverse = (node: any) : void => {
+    const traverse = (node: any): void => {
       let validChildren = [];
 
       // Logic to parse the nodes based on the users settings
@@ -90,13 +90,11 @@ const Sidebar = () => {
   // Render section
   return (
     <div className="sidebar">
-      <Navbar rootFile={rootFile}/>
-      <hr className="line_break"/>
+      <Navbar rootFile={rootFile} />
+      <hr className="line_break" />
       <div className="tree_view">
         <ul className="tree_beginning">
-          {viewData && settings ?
-            <Tree data={viewData} first={true} />
-          : null}
+          {viewData && settings ? <Tree data={viewData} first={true} /> : null}
         </ul>
       </div>
     </div>

--- a/sapling/src/webviews/components/Sidebar.tsx
+++ b/sapling/src/webviews/components/Sidebar.tsx
@@ -65,11 +65,15 @@ const Sidebar = () => {
 
       // Logic to parse the nodes based on the users settings
       for (let i = 0; i < node.children.length; i++) {
-        if (node.children[i].thirdParty && settings.thirdParty && !node.children[i].reactRouter) {
+        if (
+          node.children[i].isThirdParty &&
+          settings.thirdParty &&
+          !node.children[i].isReactRouter
+        ) {
           validChildren.push(node.children[i]);
-        } else if (node.children[i].reactRouter && settings.reactRouter) {
+        } else if (node.children[i].isReactRouter && settings.reactRouter) {
           validChildren.push(node.children[i]);
-        } else if (!node.children[i].thirdParty && !node.children[i].reactRouter) {
+        } else if (!node.children[i].isThirdParty && !node.children[i].isReactRouter) {
           validChildren.push(node.children[i]);
         }
       }

--- a/sapling/src/webviews/components/Tree.tsx
+++ b/sapling/src/webviews/components/Tree.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { useEffect, useState } from 'react';
 
 // import for the nodes
 import TreeNode from './TreeNode';
@@ -8,16 +7,18 @@ const Tree = ({ data, first }: any) => {
   // Render section
   return (
     <>
-    {/* Checks if the current iteration is the first time being run (adding in ul if not, and without ul if it is the first time) */}
-      {first ? data.map((tree: any) => {
-          return <TreeNode key={tree.id} node={tree}/>;
-        }):
+      {/* Checks if the current iteration is the first time being run (adding in ul if not, and without ul if it is the first time) */}
+      {first ? (
+        data.map((tree: any) => {
+          return <TreeNode key={tree.id} node={tree} />;
+        })
+      ) : (
         <ul>
           {data.map((tree: any) => {
-            return <TreeNode key={tree.id} node={tree}/>;
+            return <TreeNode key={tree.id} node={tree} />;
           })}
         </ul>
-      }
+      )}
     </>
   );
 };

--- a/sapling/src/webviews/components/TreeNode.tsx
+++ b/sapling/src/webviews/components/TreeNode.tsx
@@ -15,7 +15,7 @@ import 'tippy.js/dist/tippy.css';
 const TreeNode = ({ node }: any) => {
   // state variables for the users current active file and the expanded value (boolean) of the node
   const [currFile, setCurrFile] = useState(false);
-  const [expanded, setExpanded] = useState(node.expanded);
+  const [expanded, setExpanded] = useState(node.isExpanded);
 
   // useEffect that will add an event listener for 'message' to each node, in order to show which file the user is currently working in
   useEffect(() => {
@@ -76,7 +76,7 @@ const TreeNode = ({ node }: any) => {
     // Send a message to the extension on the changed checked value of the current node
     tsvscode.postMessage({
       type: 'onNodeToggle',
-      value: { id: node.id, expanded: newExpanded },
+      value: { id: node.id, expandedState: newExpanded },
     });
   };
 
@@ -100,9 +100,9 @@ const TreeNode = ({ node }: any) => {
             </label>
           )}
           {/* Checks to make sure there are no thirdParty or reactRouter node_icons */}
-          {!node.thirdParty && !node.reactRouter ? (
+          {!node.isThirdParty && !node.isReactRouter ? (
             <>
-              {node.reduxConnect ? (
+              {node.hasReduxConnect ? (
                 <Tippy
                   content={
                     <p>
@@ -145,9 +145,9 @@ const TreeNode = ({ node }: any) => {
             <span className={classString}>{node.name}</span>
           )}
           {/* Checks to make sure there are no thirdParty or reactRouter node_icons */}
-          {!node.thirdParty && !node.reactRouter ? (
+          {!node.isThirdParty && !node.isReactRouter ? (
             <>
-              {node.reduxConnect ? (
+              {node.hasReduxConnect ? (
                 <Tippy
                   content={
                     <p>

--- a/sapling/src/webviews/components/TreeNode.tsx
+++ b/sapling/src/webviews/components/TreeNode.tsx
@@ -71,12 +71,11 @@ const TreeNode = ({ node }: any) => {
   // onClick method for each node that will change the expanded/collapsed structure + send a message to the extension
   const toggleNode = () => {
     // Set state with the opposite of what is currently saved in state (expanded)
-    const newExpanded = !expanded;
-    setExpanded(newExpanded);
+    setExpanded(!expanded);
     // Send a message to the extension on the changed checked value of the current node
     tsvscode.postMessage({
       type: 'onNodeToggle',
-      value: { id: node.id, expandedState: newExpanded },
+      value: { id: node.id },
     });
   };
 

--- a/sapling/src/webviews/components/TreeNode.tsx
+++ b/sapling/src/webviews/components/TreeNode.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { useState, useEffect, Fragment } from 'react';
-import * as ReactDOM from 'react-dom';
+import { useState, useEffect } from 'react';
 
 // import tree for recursive calls
 import Tree from './Tree';
@@ -23,7 +22,7 @@ const TreeNode = ({ node }: any) => {
     window.addEventListener('message', (event) => {
       const message = event.data;
       switch (message.type) {
-        case("current-tab"): {
+        case 'current-tab': {
           // If the current node's filePath is the same as the user's current actie window, change state to true, else, change state to false
           if (message.value === node.filePath) {
             setCurrFile(true);
@@ -35,8 +34,8 @@ const TreeNode = ({ node }: any) => {
     });
     // Send message to the extension for the bolding
     tsvscode.postMessage({
-      type: "onBoldCheck",
-      value: null
+      type: 'onBoldCheck',
+      value: null,
     });
   }, []);
 
@@ -45,8 +44,8 @@ const TreeNode = ({ node }: any) => {
     // Edge case to verify that there is in fact a file path for the current node
     if (node.filePath) {
       tsvscode.postMessage({
-        type: "onViewFile",
-        value: node.filePath
+        type: 'onViewFile',
+        value: node.filePath,
       });
     }
   };
@@ -58,7 +57,7 @@ const TreeNode = ({ node }: any) => {
       return <p>None</p>;
     }
     // Case when there are props to loop through on the node
-    return Object.keys(node.props).map(prop => {
+    return Object.keys(node.props).map((prop) => {
       return <p>{prop}</p>;
     });
   };
@@ -67,7 +66,7 @@ const TreeNode = ({ node }: any) => {
   const propsList = propsGenerator();
 
   // Variable that holds the logic of whether the current node has children or not
-  const child = node.children.length > 0 ? true: false;
+  const child = node.children.length > 0 ? true : false;
 
   // onClick method for each node that will change the expanded/collapsed structure + send a message to the extension
   const toggleNode = () => {
@@ -76,63 +75,110 @@ const TreeNode = ({ node }: any) => {
     setExpanded(newExpanded);
     // Send a message to the extension on the changed checked value of the current node
     tsvscode.postMessage({
-        type: "onNodeToggle",
-        value: {id: node.id, expanded: newExpanded}
+      type: 'onNodeToggle',
+      value: { id: node.id, expanded: newExpanded },
     });
   };
 
-  const classString = "tree_label" + (node.error ? " node_error" : "");
+  const classString = 'tree_label' + (node.error ? ' node_error' : '');
 
   // Render section
   return (
     <>
-    {/* Conditional to check whether there are children or not on the current node */}
+      {/* Conditional to check whether there are children or not on the current node */}
       {child ? (
         <li>
           <input type="checkbox" checked={expanded} id={node.id} onClick={toggleNode} />
           {/* Checks for the user's current active file */}
-          {currFile ?
-            <label className={classString} htmlFor={node.id}><strong style={{ fontWeight: 800 }}>{node.name}</strong></label>
-          : <label className={classString} htmlFor={node.id}>{node.name}</label>}
+          {currFile ? (
+            <label className={classString} htmlFor={node.id}>
+              <strong style={{ fontWeight: 800 }}>{node.name}</strong>
+            </label>
+          ) : (
+            <label className={classString} htmlFor={node.id}>
+              {node.name}
+            </label>
+          )}
           {/* Checks to make sure there are no thirdParty or reactRouter node_icons */}
           {!node.thirdParty && !node.reactRouter ? (
-            <Fragment>
-              {node.reduxConnect ?
-              <Tippy content={<p><strong>Connected to Redux Store</strong></p>}>
-                <a className="redux_connect" href=""><FontAwesomeIcon icon={faStore} /></a>
+            <>
+              {node.reduxConnect ? (
+                <Tippy
+                  content={
+                    <p>
+                      <strong>Connected to Redux Store</strong>
+                    </p>
+                  }
+                >
+                  <a className="redux_connect" href="">
+                    <FontAwesomeIcon icon={faStore} />
+                  </a>
+                </Tippy>
+              ) : null}
+              <Tippy
+                content={
+                  <p>
+                    <strong>Props available:</strong>
+                    {propsList}
+                  </p>
+                }
+              >
+                <a className="node_icons" href="">
+                  <FontAwesomeIcon icon={faInfoCircle} />
+                </a>
               </Tippy>
-              : null}
-              <Tippy content={<p><strong>Props available:</strong>{propsList}</p>}>
-                <a className="node_icons" href=""><FontAwesomeIcon icon={faInfoCircle} /></a>
-              </Tippy>
-              <a className="node_icons" href="" onClick={viewFile}><FontAwesomeIcon icon={faArrowCircleRight} /></a>
-            </Fragment>
-          ): null}
+              <a className="node_icons" href="" onClick={viewFile}>
+                <FontAwesomeIcon icon={faArrowCircleRight} />
+              </a>
+            </>
+          ) : null}
           <Tree data={node.children} first={false} />
         </li>
-      ):
+      ) : (
         <li>
           {/* Checks for the user's current active file */}
-          {currFile ?
-            <span className={classString}><strong style={{ fontWeight: 800 }}>{node.name}</strong></span>
-          : <span className={classString}>{node.name}</span>
-          }
+          {currFile ? (
+            <span className={classString}>
+              <strong style={{ fontWeight: 800 }}>{node.name}</strong>
+            </span>
+          ) : (
+            <span className={classString}>{node.name}</span>
+          )}
           {/* Checks to make sure there are no thirdParty or reactRouter node_icons */}
           {!node.thirdParty && !node.reactRouter ? (
-            <Fragment>
-              {node.reduxConnect ?
-              <Tippy content={<p><strong>Connected to Redux Store</strong></p>}>
-                <a className="redux_connect" href=""><FontAwesomeIcon icon={faStore} /></a>
+            <>
+              {node.reduxConnect ? (
+                <Tippy
+                  content={
+                    <p>
+                      <strong>Connected to Redux Store</strong>
+                    </p>
+                  }
+                >
+                  <a className="redux_connect" href="">
+                    <FontAwesomeIcon icon={faStore} />
+                  </a>
+                </Tippy>
+              ) : null}
+              <Tippy
+                content={
+                  <p>
+                    <strong>Props available:</strong>
+                    {propsList}
+                  </p>
+                }
+              >
+                <a className="node_icons" href="">
+                  <FontAwesomeIcon icon={faInfoCircle} />
+                </a>
               </Tippy>
-              : null}
-              <Tippy content={<p><strong>Props available:</strong>{propsList}</p>}>
-                <a className="node_icons" href=""><FontAwesomeIcon icon={faInfoCircle} /></a>
-              </Tippy>
-              <a className="node_icons" href="" onClick={viewFile}><FontAwesomeIcon icon={faArrowCircleRight} /></a>
-            </Fragment>
-          ): null}
+              <a className="node_icons" href="" onClick={viewFile}>
+                <FontAwesomeIcon icon={faArrowCircleRight} />
+              </a>
+            </>
+          ) : null}
         </li>
-      }
+      )}
     </>
   );
 };

--- a/sapling/src/webviews/webpack.views.config.js
+++ b/sapling/src/webviews/webpack.views.config.js
@@ -3,6 +3,7 @@ const path = require('path');
 module.exports = {
   entry: path.resolve(__dirname, './pages/sidebar.tsx'),
   mode: 'production',
+  target: 'node',
   module: {
     rules: [
       {
@@ -10,7 +11,7 @@ module.exports = {
         use: {
           loader: 'ts-loader',
           options: {
-            configFile: 'tsconfig.views.json'
+            configFile: 'tsconfig.views.json',
           },
         },
         exclude: /node_modules/,
@@ -19,13 +20,13 @@ module.exports = {
         test: /\.css$/,
         use: [
           {
-            loader: "style-loader"
+            loader: 'style-loader',
           },
           {
-            loader: "css-loader"
-          }
-        ]
-      }
+            loader: 'css-loader',
+          },
+        ],
+      },
     ],
   },
   resolve: {

--- a/sapling/tsconfig.json
+++ b/sapling/tsconfig.json
@@ -10,10 +10,14 @@
     "jsx": "react",
     "sourceMap": true,
     "rootDir": "src",
-    "strict": true  /* enable all strict type-checking options */,
+
+    "strict": true /* enable all strict type-checking options (includes noImplicitAny, strictNullChecks) */,
     /* Additional Checks */
-    // "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
-    // "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */
+    "noImplicitOverride": true,
+    "noImplicitReturns": true /* Report error when not all code paths in function return a value. */,
+    // "noPropertyAccessFromIndexSignature": true,
+    "noFallthroughCasesInSwitch": true /* Report errors for fallthrough cases in switch statement. */,
+    "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */,
     // "noUnusedParameters": true,  /* Report errors on unused parameters. */
   },
   "exclude": [

--- a/sapling/webpack.config.js
+++ b/sapling/webpack.config.js
@@ -1,10 +1,6 @@
-//@ts-check
-
-'use strict';
-
 const path = require('path');
 
-/**@type {import('webpack').Configuration}*/
+/** @type {import('webpack').Configuration} */
 const config = {
   target: 'node', // vscode extensions run in a Node.js-context 📖 -> https://webpack.js.org/configuration/node/
   mode: 'none', // this leaves the source code as close as possible to the original (when packaging we set this to 'production')
@@ -15,16 +11,16 @@ const config = {
     // the bundle is stored in the 'dist' folder (check package.json), 📖 -> https://webpack.js.org/configuration/output/
     path: path.resolve(__dirname, 'dist'),
     filename: 'extension.js',
-    libraryTarget: 'commonjs2'
+    libraryTarget: 'commonjs2',
   },
   devtool: 'nosources-source-map',
   externals: {
-    vscode: 'commonjs vscode' // the vscode-module is created on-the-fly and must be excluded. Add other modules that cannot be webpack'ed, 📖 -> https://webpack.js.org/configuration/externals/
+    vscode: 'commonjs vscode', // the vscode-module is created on-the-fly and must be excluded. Add other modules that cannot be webpack'ed, 📖 -> https://webpack.js.org/configuration/externals/
     // modules added here also need to be added in the .vsceignore file
   },
   resolve: {
     // support reading TypeScript and JavaScript files, 📖 -> https://github.com/TypeStrong/ts-loader
-    extensions: ['.ts', '.js', '.tsx']
+    extensions: ['.ts', '.js', '.tsx'],
   },
   module: {
     rules: [
@@ -33,11 +29,11 @@ const config = {
         exclude: /node_modules/,
         use: [
           {
-            loader: 'ts-loader'
-          }
-        ]
+            loader: 'ts-loader',
+          },
+        ],
       },
-    ]
-  }
+    ],
+  },
 };
 module.exports = config;


### PR DESCRIPTION
### Overview
- Builds on PR #103 . New commits start here: 1cd8324.
- Updates are concentrated in **SaplingParser.ts, types/Tree.ts**
  - Some accompanying adjustments in **SidebarProvider.ts, parser.test.ts**
- Does not disrupt any existing features. Manually tested:
  - Workspace persistence of parsed tree and expanded state of all nodes including descendants of collapsed nodes.
  - Webview update on settings change, props change, file save
  - other messaging, create tree events
- [feature/webview/strict-mode,SerializableTree](https://github.com/MajorLift/sapling/tree/feature/webview/strict-mode%2CSerializableTree) (optional. builds on this PR): strict type annotations, react optimizations, utilization of new Tree class in data flow. Verified that extension-side updates are able to propagate to webview without issue. 
- **Marked as draft pending core team's assessment of compatibility with planned feature releases.**

### Details
#### A. Converted SaplingParser into stateless, static class
- .parse() is the only public (and static) method. 
- Grouped methods into objects (ParserHelpers, ASTParser, ImportParser, ExportParser).
- Converted all SaplingParser methods to pure functions where possible, and provided clear indication of unavoidable mutations (in .parser()).
- Redundant usage of parser and tree instances removed from SidebarProvider and parser.test

#### B. Converted Tree type to class and defined methods
- Migrated + adjusted .toggleNode(), .updateTree(), .#traverseTree().
- Nested nodes are accessible with .get() as follows (useful in parser test file): 
e.g. `tree.get(0, 1, 2)` is equivalent to `tree.children[0].children[1].children[2]`.
- Class internals are well-encapsulated with all fields set to private, and readonly where possible. 
  - Read access is provided with getter methods.
  - No direct write access other than through .set() method.
- Tree class objects are serializable/deserializable into/from immutable SerializedTree type to prevent data loss when converting to workspaceState Memento object.

### Motivations
#### A. Impure Functions
- .parser() relies entirely on mutating input data in-place, but this is unclear due to its non-void return type. Strong potential for confusion.
  - e.g. In the current dev branch, the updateTree/matchExpand feature continues to function without issue even after modifying lines 100-102 of SaplingParser as follows:
```
// before
const newNode = this.parser(node);
this.#traverseTree(matchExpand, newNode);
// after
this.parser(node);
this.#traverseTree(matchExpand, node);
```
- Preference for pure functions facilitates abstraction and improves type safety.

#### B. Low Cohesion
- Currently there is no conceptual benefit to modeling SaplingParser as an object that can have multiple instances, as there is no variation in parsing functionality between instances, and the only state it encapsulates is tree-related. 
  - Enabling the parser to support different configurations or multiple interfaces would be a good use case for making it instantiable again.

- Regardless, Tree state should be decoupled and encapsulated into a dedicated class.
  - Strong low-cohesion indicator: No reference to 'this.tree' in any SaplingParser class method without 'Tree' in its name.
  - Having multiple Tree object instances with different states and associated non-parsing methods is a much more useful abstraction. 

- This may be an issue that would be better addressed before it becomes more entrenched, especially if SaplingParser will need to additionally process and store parsing configuration-related state going forward.