### PR TITLE
fix(webview): restore file load button styling

### DIFF
--- a/sapling/media/styles.css
+++ b/sapling/media/styles.css
@@ -31,7 +31,16 @@
   color: var(--vscode-editorError-foreground);
 }
 
-.inputfile {
+.inputFile {
+  width: max-content;
+  background: var(--vscode-button-background);
+  padding: 0.05em .2em;
+  margin-left: .8em;
+  margin-top: .2em;
+  border-radius: 5px;
+}
+
+.inputfile + button {
   width: 0.1px;
   height: 0.1px;
   opacity: 0;
@@ -40,24 +49,19 @@
   z-index: -1;
 }
 
-.inputfile + label {
-  padding: .4em;
-  font-size: 1em;
+.inputfile + button + label {
+  font-size: 0.8em;
   font-weight: 700;
   color: var(--vscode-button-foreground);
-  background: var(--vscode-button-background);
   display: inline-block;
-  margin-left: .8em;
-  margin-top: .2em;
-  border-radius: 5px;
   transition: .2s;
 }
 
-.inputfile + label:hover {
+.inputfile + button + label:hover {
   background: var(--vscode-button-hoverBackground);
 }
 
-.inputfile + label {
+.inputfile + button + label {
   cursor: pointer;
 }
 

--- a/sapling/src/webviews/components/Navbar.tsx
+++ b/sapling/src/webviews/components/Navbar.tsx
@@ -19,12 +19,14 @@ const Navbar = ({ rootFile }: any) => {
   // Render section
   return (
     <div className="navbar">
-      <button id="file" className="inputFile" onClick={() => fileMessage()}>
-      <label htmlFor="file">
-        <FontAwesomeIcon icon={faDownload}/>
-        <strong id="strong_file">{rootFile ? ` ${rootFile}` : ' Choose a file...'}</strong>
-      </label>
-      </button>
+      <div className="inputFile">
+        <button type="submit" id="file" onClick={fileMessage}>
+        <label htmlFor="file">
+          <FontAwesomeIcon icon={faDownload}/>
+          <strong id="strong_file">{rootFile ? ` ${rootFile}` : ' Choose a file...'}</strong>
+        </label>
+        </button>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
- PR #100 introduced a slight change in the navbar file load button styling. The width is fixed to max and border corners are not rounded.
- This commit recreates the styling of the file load button in release v1.2.0.
  - width fits content
  - borders are rounded
  
 ### Current dev branch
<img width="720" alt="width-max" src="https://user-images.githubusercontent.com/34228073/147375733-93ecfc18-869a-45e5-b644-ad72bb742380.png">

### This PR
<img width="720" alt="default" src="https://user-images.githubusercontent.com/34228073/147375702-8a6a3893-e520-48da-9d16-6757235b9907.png">
<img width="720" alt="hover" src="https://user-images.githubusercontent.com/34228073/147375705-098b5347-8574-454d-b3c6-83fe6f34cdf9.png">

