### PR TITLE
feat: restore error nodes to normal color if error removed on file save

### DIFF
--- a/sapling/src/SaplingParser.ts
+++ b/sapling/src/SaplingParser.ts
@@ -192,6 +192,9 @@ export class SaplingParser {
     // Recursively parse all child components
     componentTree.children.forEach(child => this.parser(child));
 
+    // Remove any existing error messages if no errors have been found during current pass.
+    componentTree.error = '';
+
     return componentTree;
   }
 


### PR DESCRIPTION
- Previously, file nodes marked with error color would not revert to normal even after error was resolved, unless new sapling tree was created.
- Now, error color removal is performed on each .updateTree() call triggered by file saves.
- .parser() removes existing error messages after verifying absence of errors.

![node-error-color-fixed](https://user-images.githubusercontent.com/34228073/147376001-3898712f-2dab-4798-8819-d0bd93315d41.gif)
